### PR TITLE
Fix dangling paren

### DIFF
--- a/modules/init-util.el
+++ b/modules/init-util.el
@@ -370,7 +370,7 @@ afterwards."
                       't)
   (make-symbolic-link (concat local-dir "before-init.el")
                       (locate-user-emacs-file "before-init.el")
-                      't)
-  )
+                      't))
+
 
 (provide 'init-util)


### PR DESCRIPTION
"elisp isn't a curly braced language"
"elisp isn't a curly braced language"
"elisp isn't a curly braced language"
...