### PR TITLE
add-directory-tree-to-load-path: Ensure the directory exists before adding it

### DIFF
--- a/init.el
+++ b/init.el
@@ -109,9 +109,10 @@
 
 (defun add-directory-tree-to-load-path (dir)
   "Add 'dir' and all its subdirs to the load path"
-  (add-to-list 'load-path dir)
-  (let ((default-directory dir))
-    (normal-top-level-add-subdirs-to-load-path)))
+  (when (file-directory-p dir)
+    (add-to-list 'load-path dir)
+    (let ((default-directory dir))
+      (normal-top-level-add-subdirs-to-load-path))))
 
 (add-directory-tree-to-load-path exordium-extensions-dir)
 (add-directory-tree-to-load-path exordium-themes-dir)


### PR DESCRIPTION
The `~/.emacs.d/local` directory doesn't exist by default, which causes the following error at startup:
```
Warning (initialization): An error occurred while loading `/Users/jbibollet/.emacs.d/init.el':
File error: Opening directory, no such file or directory, /Users/jbibollet/.emacs.d/local
```
This commit changes the `add-directory-tree-to-load-path` to check the directory exists before adding it.

**NOTE**:
- I don't know if this should silently ignore unknown directory in that generic function.. One thing I was considering was to pass an additional optional parameter to indicate whether the directory is optional or required. While I don't know how to do that, if this is a preferred way let me know and I can take it as an exercise to learn ELISP :)