### PR TITLE
Support desktop mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,10 @@ ido.last
 recentf
 project-explorer-cache
 
+# Desktop
+.emacs.desktop
+.emacs.desktop.lock
+
 # Compiled files
 modules/*.elc
 themes/*.elc

--- a/.gitignore
+++ b/.gitignore
@@ -29,9 +29,11 @@ ido.last
 recentf
 project-explorer-cache
 
-# Desktop
+# Desktop State
 .emacs.desktop
 .emacs.desktop.lock
+saveplace
+history
 
 # Compiled files
 modules/*.elc

--- a/init.el
+++ b/init.el
@@ -153,6 +153,10 @@ the .elc exists. Also discard .elc without corresponding .el"
 (when (file-exists-p exordium-prefs-file)
   (load exordium-prefs-file))
 
+;;; Desktop
+(when exordium-desktop
+  (require 'init-desktop))
+
 ;;; Look and feel
 (require 'init-look-and-feel)   ; fonts, UI, keybindings, saving files etc.
 (require 'init-font-lock)       ; enables/disables font-lock globally.

--- a/modules/init-desktop.el
+++ b/modules/init-desktop.el
@@ -4,7 +4,8 @@
 
 (savehist-mode t) ;; minibuffer history is saved
 
-(setq save-place-file "~/.emacs.d/saveplace") ;; location to save point
+(setq save-place-file
+      (locate-user-emacs-file "saveplace"))   ;; location to save point
 (setq-default save-place t)                   ;; activate it for all buffers
 (require 'saveplace)                          ;; Automatically save place in files
 

--- a/modules/init-desktop.el
+++ b/modules/init-desktop.el
@@ -1,0 +1,12 @@
+;;;; Configuration of desktop state and history
+
+(desktop-save-mode 1) ;;the state of Emacs is saved from one session to another.
+
+(savehist-mode t) ;; minibuffer history is saved
+
+(setq save-place-file "~/.emacs.d/saveplace") ;; location to save point
+(setq-default save-place t)                   ;; activate it for all buffers
+(require 'saveplace)                          ;; Automatically save place in files
+
+
+(provide 'init-desktop)

--- a/modules/init-prefs.el
+++ b/modules/init-prefs.el
@@ -198,4 +198,11 @@ default color."
   :type  'boolean)
 
 
+;;; Desktop state
+(defcustom exordium-desktop nil
+  "Whether the desktop state is saved"
+  :group 'exordium
+  :type  'boolean)
+
+
 (provide 'init-prefs)


### PR DESCRIPTION
Support saving the desktop state: open buffers, mini-buffer history, and point location in buffers. 

Off by default. 