### PR TITLE
Find options for dired

### DIFF
--- a/modules/init-dired.el
+++ b/modules/init-dired.el
@@ -25,4 +25,8 @@
               'dired-mouse-find-file-other-window)
             ))
 
+(require 'find-dired)
+;; xargs to get options rather than exec ls on each find
+(setq find-ls-option '("-print0 | xargs -0 ls -ld" . "-ld"))
+
 (provide 'init-dired)


### PR DESCRIPTION
By default (on some platforms?) find-dired will exec ls on each
file. Xargs them and ls -ld as a group.