### PR TITLE
Fix magit warning lossage

### DIFF
--- a/modules/init-git.el
+++ b/modules/init-git.el
@@ -51,6 +51,10 @@
 ;;; Don't show "MRev" in the modeline
 (diminish 'magit-auto-revert-mode)
 
+
+;;; Turn off the horrible warning about magit auto-revert of saved buffers
+(setq magit-last-seen-setup-instructions "1.4.0")
+
 
 ;;; Git gutter fringe: display added/removed/changed lines in the left fringe.
 


### PR DESCRIPTION
Starting with 1.4.0 magit will nag you about adding a line to your init
to stop warning you about an insane dataloss scenario. Magit autoreverts
unchanged buffers on git operations. This means if you save a file, then
do something like 'git reset --hard' the file could be changed out from
underneath you and autoreverted. This has been the behavior of the
unstable magit for a long time. The answer is "DONT DO THAT".

This turns off the warning.