### PR TITLE
init-bde-style.el: Invoke fill-paragraph after bde-repunctuate

### DIFF
--- a/modules/init-bde-style.el
+++ b/modules/init-bde-style.el
@@ -836,7 +836,8 @@ or comment block. See also `repunctuate-sentences'."
         (save-excursion
           (replace-regexp "\\([]\"')]?\\)\\([.?!]\\)\\([]\"')]?\\) +"
                           "\\1\\2\\3  "
-                          nil beginning end))
+                          nil beginning end)
+          (fill-paragraph))
       (message "No region or comment"))))
 
 


### PR DESCRIPTION
Repunctuating might change alignment, so call fill-paragraph to automatically reformat the paragraph to the 79 columns rule.