### PR TITLE
Key binding to toggle git timemachine

### DIFF
--- a/modules/init-git.el
+++ b/modules/init-git.el
@@ -77,4 +77,11 @@
   (define-key exordium-git-map (kbd "d") 'git-gutter:popup-hunk)
   (define-key exordium-git-map (kbd "r") 'git-gutter:revert-hunk))
 
+
+;;; Git Timemachine
+
+(define-key exordium-git-map (kbd "t") 'git-timemachine-toggle)
+
+
+
 (provide 'init-git)


### PR DESCRIPTION
Add a keybinding, "t", to the exordium git key map to toggle git
timemachine mode.