### PR TITLE
Shell script to test exordium

### DIFF
--- a/init-test.sh
+++ b/init-test.sh
@@ -1,0 +1,4 @@
+#! /bin/sh
+emacs -Q --eval "(progn
+       (setq user-emacs-directory \"${PWD}/\")
+       (load-file \"${PWD}/init.el\"))"


### PR DESCRIPTION
Shell script to test exordium outside of ~/.emacs.d

Having the editor misconfigured while editing the init can be
inconvenient.