### PR TITLE
Factor programming modes into prog-mode 

### DIFF
--- a/init.el
+++ b/init.el
@@ -274,6 +274,9 @@ the .elc exists. Also discard .elc without corresponding .el"
 
 (update-progress-bar)
 
+;;; Prog mode
+(require 'init-prog-mode)
+
 ;;; Shell mode
 (require 'init-shell)
 

--- a/modules/init-cpp.el
+++ b/modules/init-cpp.el
@@ -22,9 +22,6 @@
 ;;; Don't show the abbrev minor mode in the mode line
 (diminish 'abbrev-mode)
 
-;;; Turn on FCI automatically
-(add-hook 'c++-mode-hook 'fci-mode)
-
 
 ;;; Highlight dead code between #if 0 and #endif
 
@@ -100,16 +97,6 @@
 ;;; Ctrl-Tab to switch between .h and .cpp
 (define-key c-mode-base-map [(control tab)] 'cpp-switch-h-cpp)
 
-
-;;; Font lock changes
-
-;;; Display TODO: and FIXME: and TBD: in red
-(when exordium-font-lock
-  (font-lock-add-keywords
-   'c++-mode
-   '(("\\<\\(FIXME\\):" 1 font-lock-warning-face prepend)
-     ("\\<\\(TBD\\):" 1 font-lock-warning-face prepend)
-     ("\\<\\(TODO\\):" 1 font-lock-warning-face prepend))))
 
 
 (provide 'init-cpp)

--- a/modules/init-elisp.el
+++ b/modules/init-elisp.el
@@ -6,12 +6,4 @@
 ;;; Bind M-C-g to helm-imenu (lists functions and variables in buffer)
 (define-key emacs-lisp-mode-map [(meta control g)] 'helm-imenu)
 
-;;; Loud face for TODOs in elisp comments
-(when exordium-font-lock
-  (add-hook 'emacs-lisp-mode-hook
-            (lambda ()
-              (font-lock-add-keywords
-               nil
-               '(("\\<\\(TODO\\|FIXME\\|TBD\\):" 1 font-lock-warning-face t))))))
-
 (provide 'init-elisp)

--- a/modules/init-javascript.el
+++ b/modules/init-javascript.el
@@ -45,15 +45,4 @@
                              activebase)))
 
 
-;;; Font lock changes
-
-;;; Display TODO: and FIXME: and TBD: in red
-(when exordium-font-lock
-  (font-lock-add-keywords
-   'js-mode
-   '(("\\<\\(FIXME\\):" 1 font-lock-warning-face prepend)
-     ("\\<\\(TBD\\):" 1 font-lock-warning-face prepend)
-     ("\\<\\(TODO\\):" 1 font-lock-warning-face prepend))))
-
-
 (provide 'init-javascript)

--- a/modules/init-look-and-feel.el
+++ b/modules/init-look-and-feel.el
@@ -153,12 +153,6 @@
 (define-key global-map [(control z)] (function undo))
 (global-set-key [(control ?`)] (function kill-this-buffer))
 
-;;; The return key
-(cond (exordium-enable-newline-and-indent
-       (global-set-key "\C-m" (function newline-and-indent))
-       (global-set-key [(shift return)] (function newline)))
-      (t
-       (global-set-key [(shift return)] (function newline-and-indent))))
 
 ;;; Meta-Control-L = switch to last buffer
 (defun switch-to-other-buffer ()

--- a/modules/init-prefs.el
+++ b/modules/init-prefs.el
@@ -105,7 +105,7 @@ which should be more efficient in particular for large buffers."
 (defcustom exordium-fci-mode :ondemand
   "Controls fill-column-indicator e.g. the 80-character ruler.
 :ondemand off by default (you need to hit C-| to toggle it),
-:always means it is always on,
+:always means it is always on, :prog means on for programming modes
 nil means it is disabled."
   :group 'exordium
   :type  'symbol)

--- a/modules/init-prog-mode.el
+++ b/modules/init-prog-mode.el
@@ -11,7 +11,6 @@
   :lighter nil
   (progn (setq require-final-newline exordium-require-final-newline-mode)))
 
-(add-hook 'prog-mode-hook 'fci-mode)
 (add-hook 'prog-mode-hook 'show-paren-mode)
 (add-hook 'prog-mode-hook 'exordium-show-trailing-whitespace-mode)
 (add-hook 'prog-mode-hook 'exordium-require-final-newline-mode)
@@ -33,6 +32,16 @@
        (define-key prog-mode-map (kbd "<S-return>") (function newline-and-indent))))
 
 
+;;; Fill comments, comment regions
+(require 'newcomment)
+(setq comment-auto-fill-only-comments 1)
+(define-key prog-mode-map (kbd "\C-c\C-c") (function comment-region))
+
+
+;;; Step through compile errors
+(global-set-key (quote [f10]) (quote next-error))
+(global-set-key (quote [(control f10)]) (quote previous-error))
+
 
 ;;; Highlight symbol
 
@@ -53,10 +62,18 @@
 ;;; Display TODO: and FIXME: and TBD: in red
 (when exordium-font-lock
   (font-lock-add-keywords
-   'c++-mode
+   'prog-mode
    '(("\\<\\(FIXME\\):" 1 font-lock-warning-face prepend)
      ("\\<\\(TBD\\):" 1 font-lock-warning-face prepend)
      ("\\<\\(TODO\\):" 1 font-lock-warning-face prepend))))
+
+
+
+
+;;; Fill column indicator
+(when (eq exordium-fci-mode :prog)
+  (add-hook 'prog-mode-hook 'fci-mode))
+
 
 (provide 'init-prog-mode)
 ;; End of file

--- a/modules/init-prog-mode.el
+++ b/modules/init-prog-mode.el
@@ -1,0 +1,62 @@
+;; Shared prog-mode-configuration
+(define-minor-mode exordium-show-trailing-whitespace-mode
+  "Enables `show-trailing-whitespace'."
+  :init-value nil
+  :lighter nil
+  (progn (setq show-trailing-whitespace exordium-show-trailing-whitespace-mode)))
+
+(define-minor-mode exordium-require-final-newline-mode
+  "Enables `require-final-newline'."
+  :init-value nil
+  :lighter nil
+  (progn (setq require-final-newline exordium-require-final-newline-mode)))
+
+(add-hook 'prog-mode-hook 'fci-mode)
+(add-hook 'prog-mode-hook 'show-paren-mode)
+(add-hook 'prog-mode-hook 'exordium-show-trailing-whitespace-mode)
+(add-hook 'prog-mode-hook 'exordium-require-final-newline-mode)
+(add-hook 'prog-mode-hook 'flyspell-prog-mode)
+
+
+;;; Electric pair: automatically close parenthesis, curly brace etc.
+;;; `electric-pair-open-newline-between-pairs'.
+(setq electric-pair-open-newline-between-pairs t)
+(when exordium-enable-electric-pair-mode
+  (add-hook 'prog-mode-hook 'electric-pair-mode))
+
+
+;;; The return key
+(cond (exordium-enable-newline-and-indent
+       (define-key prog-mode-map (kbd "<return>") (function newline-and-indent))
+       (define-key prog-mode-map (kbd "<S-return>") (function newline)))
+      (t
+       (define-key prog-mode-map (kbd "<S-return>") (function newline-and-indent))))
+
+
+
+;;; Highlight symbol
+
+(when exordium-highlight-symbol
+  (require 'highlight-symbol)
+  (highlight-symbol-nav-mode)
+  ;;
+  (add-hook 'prog-mode-hook (lambda () (highlight-symbol-mode)))
+  (setq highlight-symbol-on-navigation-p t)
+  ;; Don't show this mode in the modeline
+  (eval-after-load 'highlight-symbol
+    '(diminish 'highlight-symbol-mode)))
+
+
+
+;;; Font lock changes
+
+;;; Display TODO: and FIXME: and TBD: in red
+(when exordium-font-lock
+  (font-lock-add-keywords
+   'c++-mode
+   '(("\\<\\(FIXME\\):" 1 font-lock-warning-face prepend)
+     ("\\<\\(TBD\\):" 1 font-lock-warning-face prepend)
+     ("\\<\\(TODO\\):" 1 font-lock-warning-face prepend))))
+
+(provide 'init-prog-mode)
+;; End of file

--- a/modules/init-python.el
+++ b/modules/init-python.el
@@ -1,16 +1,4 @@
 ;;;; Configuration for Python
 
-;;; Turn on FCI automatically
-(add-hook 'python-mode-hook 'fci-mode)
-
-;;; Font lock changes
-;;; Display TODO: and FIXME: and TBD: in red
-(when exordium-font-lock
-  (font-lock-add-keywords
-   'python-mode
-   '(("\\<\\(FIXME\\):" 1 font-lock-warning-face prepend)
-     ("\\<\\(TBD\\):" 1 font-lock-warning-face prepend)
-     ("\\<\\(TODO\\):" 1 font-lock-warning-face prepend))))
-
 
 (provide 'init-python)

--- a/modules/init-ruby.el
+++ b/modules/init-ruby.el
@@ -5,13 +5,4 @@
 (add-to-list 'auto-mode-alist '("\\.rb$" . enh-ruby-mode))
 (add-to-list 'interpreter-mode-alist '("ruby" . enh-ruby-mode))
 
-;;; Font lock changes
-;;; Display TODO: and FIXME: and TBD: in red
-(when exordium-font-lock
-  (font-lock-add-keywords
-   'enh-ruby-mode
-   '(("\\<\\(FIXME\\):" 1 font-lock-warning-face prepend)
-     ("\\<\\(TBD\\):" 1 font-lock-warning-face prepend)
-     ("\\<\\(TODO\\):" 1 font-lock-warning-face prepend))))
-
 (provide 'init-ruby)

--- a/modules/init-util.el
+++ b/modules/init-util.el
@@ -323,22 +323,7 @@ Plain `C-u' (no number) uses `fill-column' as LEN."
       (message "Not found"))))
 
 
-;;; Highlight symbol
 
-(eval-when-compile
-  (require 'highlight-symbol))
-
-(when exordium-highlight-symbol
-  (require 'highlight-symbol)
-  (highlight-symbol-nav-mode)
-  ;;
-  (add-hook 'prog-mode-hook (lambda () (highlight-symbol-mode)))
-  (setq highlight-symbol-on-navigation-p t)
-  ;; Don't show this mode in the modeline
-  (eval-after-load 'highlight-symbol
-    '(diminish 'highlight-symbol-mode)))
-
-
 ;;; Buffers and windows
 
 (defun toggle-window-dedicated ()


### PR DESCRIPTION
Programming modes inherit from prog-mode. Move the common c++, python, etc code into a single 
prog-mode module