### PR TITLE
Only diminish "magit-auto-revert-mode" if registered

### DIFF
--- a/modules/init-git.el
+++ b/modules/init-git.el
@@ -49,7 +49,8 @@
 (define-key magit-status-mode-map (kbd "q") 'magit-quit-session)
 
 ;;; Don't show "MRev" in the modeline
-(diminish 'magit-auto-revert-mode)
+(when (bound-and-true-p magit-auto-revert-mode)
+  (diminish 'magit-auto-revert-mode))
 
 
 ;;; Turn off the horrible warning about magit auto-revert of saved buffers


### PR DESCRIPTION
With a vanilla clone of exordium to `~/.emacs.d` , I found that the init phase hit issues (Emacs 24.4.1).

`emacs --debug-init` showed this to be a problem in `require(init-git)`:
`signal(error ("magit-auto-revert-mode is not currently registered as a minor mode"))`

The diff should diminish `magit-auto-revert-mode` only when registered. With the change, the init phase succeeded for a vanilla `.emacs.d` clone.
(I didn't have a case where "MRev" was shown in the modeline for comparison, but the method was http://stackoverflow.com/questions/10088168/how-to-check-whether-a-minor-mode-e-g-flymake-mode-is-on )