### PR TITLE
BDEStyle: leave cursor at end of line after right-align

### DIFF
--- a/modules/init-bde-style.el
+++ b/modules/init-bde-style.el
@@ -365,7 +365,8 @@ backspace, delete, left or right."
     (if (> num-spaces 0)
         (dotimes (i num-spaces)
           (insert " "))
-      (message "Sorry, not enough space..."))))
+      (message "Sorry, not enough space...")))
+  (move-end-of-line nil))
 
 ;;; Ctrl-> to right-aligh the text after point
 (global-set-key [(control >)] 'bde-aligh-right)


### PR DESCRIPTION
When using the BDE right align function, it leaves the cursor at the beginning of the right aligned text.
This change moves it to the end of the line, which I think suits more a typical workflow.