### PR TITLE
Change material theme's fringe color

### DIFF
--- a/themes/color-theme-material.el
+++ b/themes/color-theme-material.el
@@ -109,7 +109,7 @@ names to which it refers are bound."
 
      ;; Emacs interface
      (cursor ((t (:background ,orange))))
-     (fringe ((t (:background ,background))))
+     (fringe ((t (:background ,far-background))))
 
      (linum ((t (:background ,background :foreground ,subtle
                       :underline nil :weight normal :box nil :slant normal))))


### PR DESCRIPTION
`far-background` is slightly darker than `background`, which I would prefer. `subtle` was too bright for me.