### PR TITLE
Support 'cc' extension for C++ files

### DIFF
--- a/modules/init-cpp.el
+++ b/modules/init-cpp.el
@@ -50,8 +50,9 @@
 
 (defconst exordium-cpp-header-switches
   '(("t.cpp" . ("h" "cpp"))
-    ("h"     . ("cpp" "t.cpp" "c"))
+    ("h"     . ("cpp" "cc" "t.cpp" "c"))
     ("cpp"   . ("h" "t.cpp"))
+    ("cc"    . ("h" "t.cc"))
     ("c"     . ("h")))
   "A-list of extension -> list of matching extensions")
 


### PR DESCRIPTION
when switching from header file to source file via `C-TAB`.  Useful when working with projects which use `.cc` extension for C++ source files.