### PR TITLE
shell-mode: suppress echoing of input

### DIFF
--- a/modules/init-shell.el
+++ b/modules/init-shell.el
@@ -20,7 +20,10 @@
  '(comint-get-old-input (lambda () "")) ; what to run when I press enter on a
                                         ; line above the current prompt
  '(comint-input-ring-size 5000)         ; max shell history size
- '(protect-buffer-bury-p nil)
+ '(comint-process-echoes t)             ; sub-process echoes any input; delete
+                                        ; one copy of the input so that only
+                                        ; one copy eventually appears in the
+                                        ; buffer
 )
 
 ;;; Clear the buffer


### PR DESCRIPTION
when running a sub-process in the shell.  For example, assuming this is running inside emacs shell:
```
$ python
python       #  Echoed
Python 2.7.10 (default, Aug 22 2015, 20:33:39) 
[GCC 4.2.1 Compatible Apple LLVM 7.0.0 (clang-700.0.59.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> a = 1
a = 1        # Echoed
>>> print a   
print a      # Echoed
1 
>>> 
```

Also removed an incorrect variable.