### PR TITLE
Refresh rtags-find-symbol-at-point addendum

### DIFF
--- a/modules/init-rtags.el
+++ b/modules/init-rtags.el
@@ -213,6 +213,7 @@ https://github.com/Andersbakken/rtags/blob/master/src/rtags.el c75467b"
   (interactive "P")
   (rtags-delete-rtags-windows)
   (rtags-location-stack-push)
+  (defvar init-rtags-found)
   (let ((arg (rtags-current-location))
         (tagname (or (rtags-current-symbol) (rtags-current-token)))
         (fn (buffer-file-name)))
@@ -221,20 +222,20 @@ https://github.com/Andersbakken/rtags/blob/master/src/rtags.el c75467b"
       (rtags-call-rc :path fn :path-filter prefix "-f" arg)
       (cond ((or (not rtags-follow-symbol-try-harder)
                  (= (length tagname) 0))
-             (setq found (rtags-handle-results-buffer nil nil fn)))
-            ((setq found (rtags-handle-results-buffer nil t fn)))
+             (setq init-rtags-found (rtags-handle-results-buffer nil nil fn)))
+            ((setq init-rtags-found (rtags-handle-results-buffer nil t fn)))
             (t
              (erase-buffer)
              (rtags-call-rc :path fn "-F" tagname "--definition-only" "-M" "1" "--dependency-filter" fn :path-filter prefix
                             (when rtags-wildcard-symbol-names "--wildcard-symbol-names")
                             (when rtags-symbolnames-case-insensitive "-I"))
-             (unless (setq found (rtags-handle-results-buffer nil nil fn))
+             (unless (setq init-rtags-found (rtags-handle-results-buffer nil nil fn))
                (erase-buffer)
                (rtags-call-rc :path fn "-F" tagname "-M" "1" "--dependency-filter" fn :path-filter prefix
                               (when rtags-wildcard-symbol-names "--wildcard-symbol-names")
                               (when rtags-symbolnames-case-insensitive "-I"))
-               (setq found (rtags-handle-results-buffer nil nil fn))))))
-    found))
+               (setq init-rtags-found (rtags-handle-results-buffer nil nil fn))))))
+    init-rtags-found))
 
 
 ;; Alias for C-c r . This key recenters the buffer if needed.
@@ -242,7 +243,7 @@ https://github.com/Andersbakken/rtags/blob/master/src/rtags.el c75467b"
   (lambda ()
     (interactive)
     (when (pg/rtags-find-symbol-at-point)
-      (recenter)))
+      (recenter))))
 
 ;; Alias for C-c r ,
 (define-key c-mode-base-map "\M-," (function rtags-find-references-at-point))

--- a/modules/init-rtags.el
+++ b/modules/init-rtags.el
@@ -206,55 +206,43 @@
 ;; "Ctrl-c r" is not defined by default, so we get the whole keyboard.
 (rtags-enable-standard-keybindings c-mode-base-map "\C-cr")
 
-(defun pg/rtags-handle-results-buffer (&optional noautojump)
-  "Redefinition of `rtags-handle-result-buffer' that returns t if
-success and nil if not found."
-  (setq rtags-last-request-not-indexed nil)
-  (rtags-reset-bookmarks)
-  (cond ((= (point-min) (point-max))
-         (message "RTags: No results")
-         nil)
-        ((= (count-lines (point-min) (point-max)) 1)
-         (let ((string (buffer-string)))
-           (if (rtags-not-indexed/connected-message-p string)
-               (progn
-                 (setq rtags-last-request-not-indexed t)
-                 nil)
-             (bury-buffer)
-             (rtags-goto-location string)))
-         t)
-        (t
-         (switch-to-buffer-other-window rtags-buffer-name)
-         (shrink-window-if-larger-than-buffer)
-         (goto-char (point-max))
-         (if (= (point-at-bol) (point-max))
-             (delete-char -1))
-         (rtags-init-bookmarks)
-         (rtags-mode)
-         (when (and rtags-jump-to-first-match (not noautojump))
-           (rtags-select-other-window))
-         t)))
-
 (defun pg/rtags-find-symbol-at-point (&optional prefix)
   "Redefinition of `rtags-find-symbol-at-point' that returns t on
-success and nil if not found."
+success and nil if not found. This implementation comes from
+https://github.com/Andersbakken/rtags/blob/master/src/rtags.el c75467b"
   (interactive "P")
+  (rtags-delete-rtags-windows)
   (rtags-location-stack-push)
   (let ((arg (rtags-current-location))
-        (fn (buffer-file-name))
-        (found nil))
+        (tagname (or (rtags-current-symbol) (rtags-current-token)))
+        (fn (buffer-file-name)))
     (rtags-reparse-file-if-needed)
     (with-current-buffer (rtags-get-buffer)
       (rtags-call-rc :path fn :path-filter prefix "-f" arg)
-      (setq found (pg/rtags-handle-results-buffer)))
+      (cond ((or (not rtags-follow-symbol-try-harder)
+                 (= (length tagname) 0))
+             (setq found (rtags-handle-results-buffer nil nil fn)))
+            ((setq found (rtags-handle-results-buffer nil t fn)))
+            (t
+             (erase-buffer)
+             (rtags-call-rc :path fn "-F" tagname "--definition-only" "-M" "1" "--dependency-filter" fn :path-filter prefix
+                            (when rtags-wildcard-symbol-names "--wildcard-symbol-names")
+                            (when rtags-symbolnames-case-insensitive "-I"))
+             (unless (setq found (rtags-handle-results-buffer nil nil fn))
+               (erase-buffer)
+               (rtags-call-rc :path fn "-F" tagname "-M" "1" "--dependency-filter" fn :path-filter prefix
+                              (when rtags-wildcard-symbol-names "--wildcard-symbol-names")
+                              (when rtags-symbolnames-case-insensitive "-I"))
+               (setq found (rtags-handle-results-buffer nil nil fn))))))
     found))
+
 
 ;; Alias for C-c r . This key recenters the buffer if needed.
 (define-key c-mode-base-map "\M-."
   (lambda ()
     (interactive)
     (when (pg/rtags-find-symbol-at-point)
-      (recenter-top-bottom t))))
+      (recenter)))
 
 ;; Alias for C-c r ,
 (define-key c-mode-base-map "\M-," (function rtags-find-references-at-point))


### PR DESCRIPTION
Implementation has been changed recently in original Andersbakken/rtags.
It rendered pg/rtags-handle-results-buffer not working, since
rtags-not-indexed/connected-message-p was removed. Fortunately, the
new version of rtags-handle-results-buffer returns t when match
was found and custom implementation of it is not needed any more.