### PR TITLE
Use Helm as a default completion and selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ might want to check these links:
 
 * Usability: [IDO](http://www.emacswiki.org/emacs/InteractivelyDoThings)
   (completion engine, turned on by default);
+  [Helm](http://tuhdo.github.io/helm-intro.html) (an alternative to IDO);
   [Auto Complete](https://github.com/auto-complete/auto-complete);
   [Expand Region](https://github.com/magnars/expand-region.el) (increase
   selected region by semantic units);
@@ -42,8 +43,7 @@ might want to check these links:
   tree); [Avy](https://github.com/abo-abo/avy) (jumping to visible text in 2 or
   3 key-strokes); etc.
 * Projects: [Projectile](http://batsov.com/projectile) (project-based file
-  management tool); [Helm](http://tuhdo.github.io/helm-intro.html) (an
-  alternative to IDO).
+  management tool).
 * Git: [Magit](http://magit.github.io) (git UI);
   [Git Gutter](https://github.com/syohex/emacs-git-gutter) (diffs in buffer).
 * C++:
@@ -179,7 +179,8 @@ knows about; this list is created by scanning the project root directory. The
 main usage is to jump to a file using a partial name without having to remember
 in which directory it is, but it also supports grep/ack and replace in
 project. Projectile works with Helm or IDO, so you can use either one with
-different keys.
+different keys. Alternatively, you can always use Helm by setting
+`exordium-helm-everywhere` to true.
 
 Here is an example: <kbd>C-c h</kbd> shows the list of buffers and files in the
 current project using Helm; to find a file you just need to type a few letters and the
@@ -261,8 +262,8 @@ Keybinding                             | Description
 ---------------------------------------|--------------------------------------------------
 <kbd>C-c h</kbd>                       | Find file in current project with helm
 <kbd>C-c M-h</kbd> or <kbd>C-c H</kbd> | Same, but first select project
-<kbd>C-c p p</kbd>                     | IDO: switch project
-<kbd>C-c p f</kbd>                     | IDO: find file in current project
+<kbd>C-c p p</kbd>                     | IDO: switch project (alternative: Helm)
+<kbd>C-c p f</kbd>                     | IDO: find file in current project (alternative Helm)
 <kbd>C-c p s g</kbd>                   | Grep in current project
 <kbd>C-c p s a</kbd>                   | Same but using ack
 <kbd>C-c p r</kbd>                     | Interactive query-replace on all files in project
@@ -288,14 +289,40 @@ With the cursor in the Project Explorer window, you can use these keys:
 toggle folding, <kbd>S-TAB</kbd> to fold all. <kbd>RETURN</kbd> open
 file. <kbd>w</kbd> Show path and copy it to clipboard.
 
-### Other Helm tools
+### Helm
 
-* <kbd>C-S-s</kbd> or <kbd>M-x helm-swoop</kbd>: search for text in current
-  buffer using
-  [Helm Swoop](https://github.com/ShingoFukuyama/helm-swoop). Start typing
-  text: the Helm window shows all matching lines, and you can jump from one to
-  another using the arrow keys.
-* <kbd>M-x helm-multiple-swoop-all</kbd>: same but search within all buffers.
+Helm can be set up as a primary completion and selection narrowing framework
+for most commonly used functions. You can achieve that by setting
+`exordium-helm-everywhere` to true. The following keys will use Helm:
+
+Keybinding          | Description
+--------------------|----------------------------------------------------------
+<kbd>C-c p p</kbd>  | Select project and open file with projectile.
+<kbd>C-c p f</kbd>  | Open file with projectile.
+<kbd>C-x C-r</kbd>  | Open recent file.
+<kbd>M-x</kbd>      | Execute command.
+<kbd>M-y</kbd>      | Select yank pop.
+<kbd>C-x b</kbd>    | Switch buffer.
+<kbd>C-x C-f</kbd>  | Find file.
+
+#### Other Helm tools
+
+Helm is a pretty good when you need quickly scan search results. The below commands
+will start different search modes. By default, they will use symbol under the point.
+However if it is not there just start typing text: the Helm window shows all
+matching lines, and you can jump from one to another using the arrow keys.
+
+Some of them will use  [Helm Swoop](https://github.com/ShingoFukuyama/helm-swoop) while
+the reminder will use [Silver Searcher](https://github.com/ggreer/the_silver_searcher).
+The latter, abbreviated `Ag`, being substitute to `grep` and `ack` has support for regular
+expressions.
+
+* <kbd>C-S-a</kbd>: Ag search for text in current projectile project.
+* <kbd>C-S-s</kbd> or <kbd>M-x helm-swoop</kbd>: Swoop search for text in current buffer.
+* <kbd>C-S-d</kbd>: Ag search for text, but ask for directory to start first.
+* <kbd>C-S-f</kbd>: Ag search for text in current buffer (similar to Swoop).
+* <kbd>C-S-r</kbd>: Ag search starting from project root.
+* <kbd>M-x helm-multiple-swoop-all</kbd>: Swoop search within all buffers.
 
 ## Git
 
@@ -677,11 +704,15 @@ Modules can be individually commented out if needed:
 (require 'init-linum)           ; line numbers
 
 ;;; Usability
+(require 'init-window-manager)  ; navigate between windows
 (require 'init-util)            ; utilities like match paren, bookmarks...
 (require 'init-ido)             ; supercharged completion engine
-(require 'init-autocomplete)    ; auto-completion
+(require 'init-highlight)       ; highlighting current line, symbol under point
+(when exordium-auto-complete
+  (require 'init-autocomplete)) ; auto-completion (see below for RTags AC)
 (when exordium-helm-projectile  ; find files anywhere in project
   (require 'init-helm-projectile))
+(require 'init-helm)            ; setup helm
 
 ;;; Magit and git gutter
 (require 'init-git)

--- a/init.el
+++ b/init.el
@@ -154,6 +154,7 @@ Check the warnings and messages buffers, or restart with --debug-init")
                                          (helm                    . "melpa-pinned")
                                          (helm-descbinds          . "melpa-pinned")
                                          (helm-swoop              . "melpa-pinned")
+                                         (helm-ag                 . "melpa-pinned")
                                          (ido-ubiquitous          . "melpa-pinned")
                                          (projectile              . "melpa-pinned")
                                          (helm-projectile         . "melpa-pinned")
@@ -273,6 +274,7 @@ the .elc exists. Also discard .elc without corresponding .el"
   (require 'init-autocomplete)) ; auto-completion (see below for RTags AC)
 (when exordium-helm-projectile  ; find files anywhere in project
   (require 'init-helm-projectile))
+(require 'init-helm)            ; setup helm
 
 (update-progress-bar)
 

--- a/modules/init-helm-projectile.el
+++ b/modules/init-helm-projectile.el
@@ -4,7 +4,9 @@
 ;;; ----------------- -------------------------------------------------------
 ;;; Key               Definition
 ;;; ----------------- -------------------------------------------------------
-;;; C-c h             Open file with helm/projectile (current project).
+;;; C-c p p           [Opt remap] Select project and open file with helm.
+;;; C-c p f           [Opt remap] Open file with helm-projectile (current project).
+;;; C-c h             Open file with helm-projectile (current project).
 ;;; C-c M-h           Same but first select the project.
 ;;; or C-c H
 ;;; C-c p s g         Grep in project.
@@ -23,6 +25,13 @@
 (global-set-key [(control c)(h)] (function helm-projectile))
 (global-set-key [(control c)(H)] (function helm-projectile-switch-project))
 (global-set-key [(control c)(meta h)] (function helm-projectile-switch-project))
+(when exordium-helm-everywhere
+  (substitute-key-definition
+   'projectile-switch-project 'helm-projectile-switch-project
+   projectile-mode-map)
+  (substitute-key-definition
+   'projectile-find-file 'helm-projectile
+   projectile-mode-map))
 
 
 ;;; Do not show these files in helm buffer
@@ -61,4 +70,10 @@
 (define-key global-map [(control c)(e)] (function project-explorer-open))
 
 
+;;; Use fuzzy matching for helm-projectile when requested
+(when exordium-helm-fuzzy-match
+  (setq helm-projectile-fuzzy-match t))
+
+
+
 (provide 'init-helm-projectile)

--- a/modules/init-helm.el
+++ b/modules/init-helm.el
@@ -1,0 +1,41 @@
+;;;; Helm - see http://tuhdo.github.io/helm-intro.html
+;;;
+;;; ----------------- -------------------------------------------------------
+;;; Key               Definition
+;;; ----------------- -------------------------------------------------------
+;;; M-x               Remap standard: Execute command with helm.
+;;; M-y               Remap standard: Yank with helm.
+;;; C-x b             Remap standard: Switch buffer with helm.
+;;; C-x C-f           Remap standard: Find file with helm.
+;;; C-S-r             Search with Ag: from project root.
+;;; C-S-d             Search with Ag: ask for directory first.
+;;; C-S-f             Search with Ag: this file (like Swoop).
+;;; C-S-a             Search with Ag: in current projectile project.
+
+(require 'helm)
+(require 'helm-projectile)
+(require 'helm-ag)
+
+
+(global-set-key (kbd "C-S-r") 'helm-ag-project-root)
+(global-set-key (kbd "C-S-d") 'helm-do-ag)
+(global-set-key (kbd "C-S-f") 'helm-do-ag-this-file)
+(global-set-key (kbd "C-S-a") 'helm-projectile-ag)
+
+(when exordium-helm-everywhere
+  (global-set-key (kbd "M-x") 'helm-M-x)
+  (global-set-key (kbd "C-x C-f") 'helm-find-files)
+  (global-set-key (kbd "M-y") 'helm-show-kill-ring)
+  (global-set-key (kbd "C-x b") 'helm-mini))
+
+(when exordium-helm-fuzzy-match
+  (setq helm-M-x-fuzzy-match t
+        helm-buffers-fuzzy-matching t
+        helm-recentf-fuzzy-match t
+        helm-ff-fuzzy-matching t
+        helm-ag-fuzzy-match t
+        helm-buffer-details-flag nil
+        helm-ag-insert-at-point 'symbol))
+
+
+(provide 'init-helm)

--- a/modules/init-ido.el
+++ b/modules/init-ido.el
@@ -3,7 +3,7 @@
 ;;; -------------- -------------------------------------------------------
 ;;; Key            Definition
 ;;; -------------- -------------------------------------------------------
-;;; C-c C-r        Open recent file with IDO
+;;; C-x C-r        Open recent file with IDO or Helm.
 
 (require 'ido)
 (ido-mode 'both)
@@ -35,6 +35,7 @@
 ;; `abbreviate-file-name' abbreviates home dir to ~/ in the file list
 ;; Custom abbreviations can be added to `directory-abbrev-alist'.
 (require 'recentf)
+(require 'helm)
 
 (recentf-mode 1)
 (setq recentf-max-menu-items 25)
@@ -46,7 +47,10 @@
    (ido-completing-read "Recentf open: "
                         (mapcar 'abbreviate-file-name recentf-list)
                         nil t)))
-(define-key global-map [(control x)(control r)] 'ido-find-recentf)
+(cond (exordium-helm-everywhere
+       (define-key global-map [(control x)(control r)] 'helm-recentf))
+      (t
+       (define-key global-map [(control x)(control r)] 'ido-find-recentf)))
 
 
 (provide 'init-ido)

--- a/modules/init-prefs.el
+++ b/modules/init-prefs.el
@@ -265,6 +265,18 @@ Disables flyspell if set to nil."
   :type  'boolean)
 
 
+;;; See init-helm.el
+(defcustom exordium-helm-everywhere nil
+  "Whether Helm should be used as a substitute for common key bindings."
+  :group 'exordium
+  :type  'boolean)
+
+(defcustom exordium-helm-fuzzy-match t
+  "Whether Helm should use fuzzy matching for searches."
+  :group 'exordium
+  :type  'boolean)
+
+
 ;;; Desktop state
 (defcustom exordium-desktop nil
   "Whether the desktop state is saved"


### PR DESCRIPTION
Add an option to use Helm as a replacement for IDO. By default it
is off. However when exordium-helm-everywhere is true Helm is used
by default.

Optionally allow for fuzzy matching when selection is narrowed
(default true).

Add a few keybindings to use Silver Searcher (Ag) with helm for
quick code scanning.