### PR TITLE
Don't set fonts if no fonts available

### DIFF
--- a/modules/init-look-and-feel.el
+++ b/modules/init-look-and-feel.el
@@ -55,7 +55,7 @@
                         :height size
                         :weight 'normal)))
 
-(when exordium-preferred-fonts
+(when exordium-available-preferred-fonts
   (exordium-set-font))
 
 


### PR DESCRIPTION
For example, when starting -nw.