### PR TITLE
Use helm also for rtags when requested everywhere

### DIFF
--- a/modules/init-rtags-helm.el
+++ b/modules/init-rtags-helm.el
@@ -20,6 +20,11 @@
   :group 'rtags
   :type 'boolean)
 
+(when exordium-helm-everywhere
+  (setq rtags-helm-show-variables t)
+  (setq rtags-helm-show-enums t)
+  (setq rtags-use-helm t))
+
 (defun rtags-helm-sort-list (pairs)
   (sort pairs #'(lambda (p1 p2) (< (cdr p1) (cdr p2)))))
 


### PR DESCRIPTION
When `exordium-helm-everyhere` is set to true turn on
helm functions from rtags as well as Exordium ones.