### PR TITLE
Fix modeline for Projectile/Tramp

### DIFF
--- a/modules/init-powerline.el
+++ b/modules/init-powerline.el
@@ -28,10 +28,15 @@
 (when (featurep 'init-helm-projectile)
   (eval-after-load "projectile"
     `(setq projectile-mode-line
-           `(:eval (list " ["
-                         (propertize (projectile-project-name)
-                                     'face 'exordium-project-name)
-                         "]")))))
+           `(:eval (if (file-remote-p default-directory)
+                       (list " ["
+                             (propertize "*remote*"
+                                         'face 'exordium-project-name)
+                             "]")
+                     (list " ["
+                            (propertize (projectile-project-name)
+                                        'face 'exordium-project-name)
+                            "]"))))))
 
 
 ;;; Faces for our powerline theme. They are defined here and customized within


### PR DESCRIPTION
Projectile and Tramp don't get along if the directory is remote. Change
the modeline setting in powerline to not call projectile-project-name.