### PR TITLE
Make sure rtags-helm is loaded

### DIFF
--- a/modules/init-rtags-helm.el
+++ b/modules/init-rtags-helm.el
@@ -9,6 +9,7 @@
 
 (require 'rtags)
 (require 'helm)
+(require 'rtags-helm)
 (require 'init-prefs)
 
 (defcustom rtags-helm-show-variables nil


### PR DESCRIPTION
rtags-helm has it's own module since [Oct/17 commit to rtags](https://github.com/Andersbakken/rtags/commit/89af223e64d9d918517c9ae7b29e9550389105dd#diff-7102a2397f5f68a580cf204addc04da9).