### PR TITLE
Add company-mode as an alternative to auto-complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ might want to check these links:
 * Usability: [IDO](http://www.emacswiki.org/emacs/InteractivelyDoThings)
   (completion engine, turned on by default);
   [Helm](http://tuhdo.github.io/helm-intro.html) (an alternative to IDO);
-  [Auto Complete](https://github.com/auto-complete/auto-complete);
+  [Auto Complete](https://github.com/auto-complete/auto-complete) and
+  [Company](http://http://company-mode.github.io) (completion engines)
   [Expand Region](https://github.com/magnars/expand-region.el) (increase
   selected region by semantic units);
   [Fill Column Indicator](http://www.emacswiki.org/emacs/FillColumnIndicator)
@@ -162,12 +163,12 @@ Keybinding              | Description
 <kbd>C-c S-ARROW</kbd>  | Move the windows themselves.
 <kbd>M-p NUMBER</kbd>   | Jump to the specified window number using [ace-window](https://github.com/abo-abo/ace-window). If you only have 2 windows, cycle between them.
 
-Auto-complete:
+Auto-complete/Company:
 
 Keybinding         | Description
 -------------------|-----------------------------------------------------------
-<kbd>C-.</kbd>     | Force trigger auto-complete.
-<kbd>ESC</kbd>     | Abort auto-complete.
+<kbd>C-.</kbd>     | Force trigger auto-complete/company-complete.
+<kbd>ESC</kbd>     | Abort auto-complete/company-complete.
 
 Tip: if you are looking for a particular key and you know it starts with a
 given prefix, type the prefix followed by <kbd>C-h</kbd>: Emacs will display
@@ -401,8 +402,8 @@ Keybinding         | Description
 which replaces a keyword by a template after you hit the trigger key. YASnippet
 is only enabled for C++ mode currently. The trigger key is set to <kbd>C-c
 y</kbd> because the default TAB key is already way overused between intention
-and auto-complete. You can easily use a function key if you prefer by adding
-this in your `after-init.el`:
+and auto-complete/company-complete. You can easily use a function key if you prefer
+by adding this in your `after-init.el`:
 
 ```lisp
 (define-key yas-minor-mode-map (kbd "<f2>") 'yas-expand)
@@ -729,6 +730,12 @@ Possible issues:
 * Auto-complete for header files does not understand when you are switching
   project.
 
+#### Company
+
+As an alternative to `auto-complete` you can choose `company-mode`. You can
+do that by setting `exordium-complete-mode` to `:company`. It will use
+RTags as a completion engine when `rdm` is started.
+
 ## Lisp
 
 Coming soon: Emacs Lisp, Common Lisp and Clojure.
@@ -807,8 +814,10 @@ Modules can be individually commented out if needed:
 (require 'init-util)            ; utilities like match paren, bookmarks...
 (require 'init-ido)             ; supercharged completion engine
 (require 'init-highlight)       ; highlighting current line, symbol under point
-(when exordium-auto-complete
-  (require 'init-autocomplete)) ; auto-completion (see below for RTags AC)
+(cond ((eq exordium-complete-mode :auto-complete)
+       (require 'init-autocomplete)) ; auto-completion (see below for RTags AC)
+      ((eq exordium-complete-mode :company)
+       (require 'init-company))) ; company mode (rtags are on by default)
 (when exordium-helm-projectile  ; find files anywhere in project
   (require 'init-helm-projectile))
 (require 'init-helm)            ; setup helm

--- a/doc/code-organization.md
+++ b/doc/code-organization.md
@@ -81,6 +81,8 @@ pull. For example you can put something like this in your *prefs.el*:
   configures Helm.
 * [init-autocomplete.el](https://raw.github.com/philippe-grenet/exordium/master/modules/init-autocomplete.el):
   configures autocomplete with default sources (non-RTags).
+* [init-company.el](https://raw.github.com/philippe-grenet/exordium/master/modules/init-company.el):
+  configures company mode with default sources and RTags.
 * [init-helm-projectile.el](https://raw.github.com/philippe-grenet/exordium/master/modules/init-helm-projectile.el):
   configures Helm when used with Projectile.
 * [init-git.el](https://raw.github.com/philippe-grenet/exordium/master/modules/init-git.el):

--- a/init.el
+++ b/init.el
@@ -281,8 +281,10 @@ the .elc exists. Also discard .elc without corresponding .el"
 (require 'init-util)            ; utilities like match paren, bookmarks...
 (require 'init-ido)             ; supercharged completion engine
 (require 'init-highlight)       ; highlighting current line, symbol under point
-(when exordium-auto-complete
-  (require 'init-autocomplete)) ; auto-completion (see below for RTags AC)
+(cond ((eq exordium-complete-mode :auto-complete)
+       (require 'init-autocomplete)) ; auto-completion (see below for RTags AC)
+      ((eq exordium-complete-mode :company)
+       (require 'init-company))) ; company mode (rtags are on by default)
 (when exordium-helm-projectile  ; find files anywhere in project
   (require 'init-helm-projectile))
 (require 'init-helm)            ; setup helm

--- a/modules/init-company.el
+++ b/modules/init-company.el
@@ -1,0 +1,18 @@
+;;;; company-mode
+
+(require 'rtags)
+(require 'company)
+
+;; Turn on rtags completions
+(setq rtags-completions-enabled t)
+
+;; Turn on company mode everywhere
+(global-company-mode)
+
+;; Use ESC to escape company-complete (in addition to C-g)
+(define-key company-active-map (kbd "<escape>") 'company-abort)
+
+;; Key to force trigger company-complete
+(define-key company-mode-map [(control .)] 'company-complete)
+
+(provide 'init-company)

--- a/modules/init-prefs.el
+++ b/modules/init-prefs.el
@@ -170,11 +170,12 @@ i.e., with git pull."
 
 ;;; Autocomplete -- see init-autocomplete.el
 
-(defcustom exordium-auto-complete t
-  "Whether auto-complete is turned on or off by default. See also
+(defcustom exordium-complete-mode :auto-complete
+  "Slect the completion engine for exordium. Possible values are
+  :auto-complete, :company, and nil. Default is :auto-complete. See also
   `exordium-rtags-auto-complete'."
   :group 'exordium
-  :type  'boolean)
+  :type  'symbol)
 
 
 ;;; Themes -- see themes directory

--- a/modules/init-rtags.el
+++ b/modules/init-rtags.el
@@ -233,7 +233,11 @@ open-buffer is true."
     (let ((process (if exordium-rtags-rdm-args
                        (start-process "rdm" buffer "rdm" exordium-rtags-rdm-args)
                        (start-process "rdm" buffer "rdm"))))
-      (message "Started rdm - PID %d" (process-id process)))))
+      (message "Started rdm - PID %d" (process-id process))))
+  ;; Add RTags to company backends
+  (when (and (eq exordium-complete-mode :company)
+             (not (member 'company-rtags company-backends)))
+    (push 'company-rtags company-backends)))
 
 (defun rtags-start ()
   "Start the rdm deamon in a subprocess and display output in a
@@ -245,6 +249,10 @@ buffer. Also start the RTag diagostics mode."
 (defun rtags-stop ()
   "Stop both RTags diagnostics and rdm, if they are running."
   (interactive)
+  ;; Remove RTags from company backends
+  (when (member 'company-rtags company-backends)
+    (message "rmoving rtags company mode")
+    (setq company-backends (delete 'company-rtags company-backends)))
   ;; Stop RTags Diagnostics and kill its buffer without prompt
   (when (and rtags-diagnostics-process
              (not (eq (process-status rtags-diagnostics-process) 'exit)))

--- a/modules/init-util.el
+++ b/modules/init-util.el
@@ -288,7 +288,7 @@ With argument, do this that many times."
 ;;; https://github.com/alpaker/Fill-Column-Indicator/issues/21
 
 (when (and exordium-fci-mode
-           exordium-auto-complete
+           (eq exordium-complete-mode :auto-complete)
            exordium-fci-fix-autocomplete-bug)
   (require 'fill-column-indicator)
   (require 'popup)


### PR DESCRIPTION
This enables company-mode (globally) as an alternative to
auto-complete. While I haven't tested it extensively yet it
integrates with RTags pretty nicely and seems to work out of the box.

You can change which mode you want to use by setting
exordium-complete-mode to either :auto-complete or :company (or nil to
don't choose either).