### PR TITLE
Only delete rtags-company when in company mode

### DIFF
--- a/modules/init-rtags.el
+++ b/modules/init-rtags.el
@@ -250,8 +250,8 @@ buffer. Also start the RTag diagostics mode."
   "Stop both RTags diagnostics and rdm, if they are running."
   (interactive)
   ;; Remove RTags from company backends
-  (when (member 'company-rtags company-backends)
-    (message "rmoving rtags company mode")
+  (when (and (eq exordium-complete-mode :company)
+             (member 'company-rtags company-backends))
     (setq company-backends (delete 'company-rtags company-backends)))
   ;; Stop RTags Diagnostics and kill its buffer without prompt
   (when (and rtags-diagnostics-process


### PR DESCRIPTION
The `company-backends` is nil otherwise and that causes
`memeber` to produce diagnostics.