### PR TITLE
Clean up line mode for company

### DIFF
--- a/modules/init-company.el
+++ b/modules/init-company.el
@@ -2,6 +2,7 @@
 
 (require 'rtags)
 (require 'company)
+(require 'diminish)
 
 ;; Turn on rtags completions
 (setq rtags-completions-enabled t)
@@ -14,5 +15,9 @@
 
 ;; Key to force trigger company-complete
 (define-key company-mode-map [(control .)] 'company-complete)
+
+;; Clean up mode-line.
+(eval-after-load "company"
+  '(diminish 'company-mode "CA"))
 
 (provide 'init-company)


### PR DESCRIPTION
'company' is a bit too long to my taste. Let's use 'CA' which is
not only shorter, not only respects Complete Any but is an anagram
of 'AC' used by the competition a.k.a auto-complete.