### PR TITLE
Easier to type binding for goto-last-change-reverse (C-x C-/)

### DIFF
--- a/modules/init-util.el
+++ b/modules/init-util.el
@@ -124,6 +124,7 @@
 (require 'goto-chg)
 (define-key global-map [(control x)(control \\)] 'goto-last-change)
 (define-key global-map [(control x)(control |)] 'goto-last-change-reverse)
+(define-key global-map [(control x)(control /)] 'goto-last-change-reverse)
 
 
 ;;; Insert date/time


### PR DESCRIPTION
C-x C-/ as a reverse of C-x C-\ is both more predictable and easier to type.