### PR TITLE
Use `g` to iwyu reocmpile

### DIFF
--- a/README.md
+++ b/README.md
@@ -771,6 +771,7 @@ Keybinding            | Description
 ----------------------|-----------------------------------------------------------
 <kbd>C-c w e</kbd>    | Run `include-what-you-use` for the current buffer.
 <kbd>C-c w d</kbd>    | Show/hide the diagnostics buffer without force reparsing.
+<kbd>g</kbd>          | Reparse recent file (in `IWYU-mode` buffer).
 
 ## Lisp
 


### PR DESCRIPTION
I caught myself hitting `g` in the IWYU result buffer. But it was spawning full compilation. Not exactly what I was expecting. Now it's more intuitive - at least to me.