### PR TITLE
Smarten the member function detection.

### DIFF
--- a/modules/init-bde-style.el
+++ b/modules/init-bde-style.el
@@ -135,6 +135,18 @@
 
 (eval-when-compile (defvar c-syntactic-context))
 
+(defun bde-is-member-function-declaration ()
+  "Return whether the line ending resembles the member function declaration."
+  (re-search-forward
+   (concat ") *\\(const\\)?"
+           " *\\(noexcept\\|BSLS_CPP11_NOEXCEPT\\)?"
+           " *\\(\\(= *\\(0\\|de\\(fault\\|lete\\)\\)\\)"
+           "\\|BSLS_CPP11_DE\\(FAULT\\|LETED\\)"
+           "\\|override\\|BSLS_CPP11_OVERRIDE\\)?"
+           " *\\(&\\(&\\)?\\)?"
+           " *; *$")
+           (point-at-eol) t))
+
 (defun bde-comment-offset (element)
   "Custom line-up function for BDE comments.
 Return a symbol for the correct indentation level at the
@@ -165,8 +177,7 @@ current cursor position, if the cursor is within a class definition:
                  ;; looking at a comment line
                  (setq comment-column (- (current-column) 2))
                  (forward-line -1))
-                ((re-search-forward ") *\\(const\\)? *\\(= *0\\)? *; *$"
-                                    (point-at-eol) t)
+                ((bde-is-member-function-declaration)
                  ;; looking at end of method declaration
                  (return '+))
                 ((re-search-forward "} *$" (point-at-eol) t)

--- a/modules/init-bde-style.t.el
+++ b/modules/init-bde-style.t.el
@@ -10,11 +10,11 @@
 
 (cl-defstruct test-case
   input               ;; string: initial buffer content
-  output              ;; string: expected final buffer content
+  (output nil)        ;; string: expected final buffer content
   (use-region nil)    ;; select the whole buffer?
   (cursor-pos 0))     ;; move cursor to this position (nil = end of buffer)
 
-(defmacro with-test-case (tst &rest body)
+(defmacro with-test-case-output (tst &rest body)
   "Execute BODY using a temporary buffer created according to test case TST.
 TST defines the inital content, cursor position, and if a region
 is selected or not. Then compare the content of the buffer with
@@ -37,6 +37,24 @@ content string"
        ;; Return the content of the buffer as raw string (without font-lock)
        (substring-no-properties (buffer-string)))))
 
+(defmacro with-test-case-return (tst &rest body)
+  "Execute BODY using a temporary buffer created according to test case TST.
+TST defines the inital content, cursor position, and if a region
+is selected or not. Return the body return value."
+  (declare (indent defun))
+  `(let ((input      (test-case-input ,tst))
+         (use-region (test-case-use-region ,tst))
+         (cursor-pos (test-case-cursor-pos ,tst)))
+     (with-temp-buffer
+       ;; Set the initial state of the buffer
+       (rename-buffer "mqbnet_foo.h")
+       (c++-mode)
+       (insert input)
+       (when cursor-pos (goto-char cursor-pos))
+       (when use-region (mark-whole-buffer))
+       ;; Execute body
+       ,@body)))
+
 
 ;; Tests for `bde-insert-redundant-include-guard-region'
 
@@ -48,7 +66,7 @@ content string"
 #include <mqbscm_version.h>
 #endif
 ")))
-    (should (string= (with-test-case tst
+    (should (string= (with-test-case-output tst
                        (bde-insert-redundant-include-guard-region))
                    (test-case-output tst)))))
 
@@ -60,7 +78,7 @@ content string"
 #endif
 "
                              :cursor-pos nil)))
-    (should (string= (with-test-case tst
+    (should (string= (with-test-case-output tst
                        (bde-insert-redundant-include-guard-region))
                      (test-case-output tst)))))
 
@@ -83,9 +101,325 @@ content string"
 }
 "
                              :cursor-pos 62)))
-    (should (string= (with-test-case tst
+    (should (string= (with-test-case-output tst
                        (bde-align-funcall))
                      (test-case-output tst)))))
+
+
+;; Tests for `bde-is-member-function-declaration'
+
+
+(ert-deftest test-bde-is-member-function-declaration-basic-1 ()
+  (let ((tst (make-test-case :input "void foo();")))
+    (should (with-test-case-return tst (bde-is-member-function-declaration)))))
+
+(ert-deftest test-bde-is-member-function-declaration-basic-2 ()
+  (let ((tst (make-test-case :input "void foo() ;")))
+    (should (with-test-case-return tst (bde-is-member-function-declaration)))))
+
+(ert-deftest test-bde-is-member-function-declaration-basic-3 ()
+  (let ((tst (make-test-case :input "void foo(); ")))
+    (should (with-test-case-return tst (bde-is-member-function-declaration)))))
+
+(ert-deftest test-bde-is-member-function-declaration-basic-4 ()
+  (let ((tst (make-test-case :input "void foo()")))
+    (should (not (with-test-case-return tst (bde-is-member-function-declaration))))))
+
+(ert-deftest test-bde-is-member-function-declaration-c-1 ()
+  (let ((tst (make-test-case :input "void foo() const;")))
+    (should (with-test-case-return tst (bde-is-member-function-declaration)))))
+
+(ert-deftest test-bde-is-member-function-declaration-c-2 ()
+  (let ((tst (make-test-case :input "void foo() const ;")))
+    (should (with-test-case-return tst (bde-is-member-function-declaration)))))
+
+(ert-deftest test-bde-is-member-function-declaration-c-3 ()
+  (let ((tst (make-test-case :input "void foo() const; ")))
+    (should (with-test-case-return tst (bde-is-member-function-declaration)))))
+
+(ert-deftest test-bde-is-member-function-declaration-c-4 ()
+  (let ((tst (make-test-case :input "void foo() const")))
+    (should (not (with-test-case-return tst (bde-is-member-function-declaration))))))
+
+(ert-deftest test-bde-is-member-function-declaration-basic-pure-1 ()
+  (let ((tst (make-test-case :input "void foo()=0;")))
+    (should (with-test-case-return tst (bde-is-member-function-declaration)))))
+
+(ert-deftest test-bde-is-member-function-declaration-basic-pure-2 ()
+  (let ((tst (make-test-case :input "void foo() = 0 ;")))
+    (should (with-test-case-return tst (bde-is-member-function-declaration)))))
+
+(ert-deftest test-bde-is-member-function-declaration-basic-pure-3 ()
+  (let ((tst (make-test-case :input "void foo() =0 ; ")))
+    (should (with-test-case-return tst (bde-is-member-function-declaration)))))
+
+(ert-deftest test-bde-is-member-function-declaration-basic-pure-4 ()
+  (let ((tst (make-test-case :input "void foo()= 0;")))
+    (should (with-test-case-return tst (bde-is-member-function-declaration)))))
+
+(ert-deftest test-bde-is-member-function-declaration-c-pure-1 ()
+  (let ((tst (make-test-case :input "void foo() const=0;")))
+    (should (with-test-case-return tst (bde-is-member-function-declaration)))))
+
+(ert-deftest test-bde-is-member-function-declaration-c-pure-2 ()
+  (let ((tst (make-test-case :input "void foo() const = 0 ;")))
+    (should (with-test-case-return tst (bde-is-member-function-declaration)))))
+
+(ert-deftest test-bde-is-member-function-declaration-c-pure-3 ()
+  (let ((tst (make-test-case :input "void foo() const =0; ")))
+    (should (with-test-case-return tst (bde-is-member-function-declaration)))))
+
+(ert-deftest test-bde-is-member-function-declaration-c-pure-4 ()
+  (let ((tst (make-test-case :input "void foo() const= 0;")))
+    (should (with-test-case-return tst (bde-is-member-function-declaration)))))
+
+(ert-deftest test-bde-is-member-function-declaration-basic-delete-1 ()
+  (let ((tst (make-test-case :input "void foo()=delete;")))
+    (should (with-test-case-return tst (bde-is-member-function-declaration)))))
+
+(ert-deftest test-bde-is-member-function-declaration-basic-delete-2 ()
+  (let ((tst (make-test-case :input "void foo() = delete ;")))
+    (should (with-test-case-return tst (bde-is-member-function-declaration)))))
+
+(ert-deftest test-bde-is-member-function-declaration-basic-delete-3 ()
+  (let ((tst (make-test-case :input "void foo() =delete ; ")))
+    (should (with-test-case-return tst (bde-is-member-function-declaration)))))
+
+(ert-deftest test-bde-is-member-function-declaration-basic-delete-4 ()
+  (let ((tst (make-test-case :input "void foo()= delete;")))
+    (should (with-test-case-return tst (bde-is-member-function-declaration)))))
+
+(ert-deftest test-bde-is-member-function-declaration-basic-delete-pure-1 ()
+  (let ((tst (make-test-case :input "void foo() = delete =0;")))
+    (should (not (with-test-case-return tst (bde-is-member-function-declaration))))))
+
+(ert-deftest test-bde-is-member-function-declaration-basic-delete-pure-2 ()
+  (let ((tst (make-test-case :input "void foo() = delete = 0;")))
+    (should (not (with-test-case-return tst (bde-is-member-function-declaration))))))
+
+(ert-deftest test-bde-is-member-function-declaration-basic-default-1 ()
+  (let ((tst (make-test-case :input "void foo()=default;")))
+    (should (with-test-case-return tst (bde-is-member-function-declaration)))))
+
+(ert-deftest test-bde-is-member-function-declaration-basic-default-2 ()
+  (let ((tst (make-test-case :input "void foo() = default ;")))
+    (should (with-test-case-return tst (bde-is-member-function-declaration)))))
+
+(ert-deftest test-bde-is-member-function-declaration-basic-default-3 ()
+  (let ((tst (make-test-case :input "void foo() =default ; ")))
+    (should (with-test-case-return tst (bde-is-member-function-declaration)))))
+
+(ert-deftest test-bde-is-member-function-declaration-basic-default-4 ()
+  (let ((tst (make-test-case :input "void foo()= default;")))
+    (should (with-test-case-return tst (bde-is-member-function-declaration)))))
+
+(ert-deftest test-bde-is-member-function-declaration-basic-default-pure-1 ()
+  (let ((tst (make-test-case :input "void foo() = default =0;")))
+    (should (not (with-test-case-return tst (bde-is-member-function-declaration))))))
+
+(ert-deftest test-bde-is-member-function-declaration-basic-default-pure-2 ()
+  (let ((tst (make-test-case :input "void foo() = default = 0;")))
+    (should (not (with-test-case-return tst (bde-is-member-function-declaration))))))
+
+(ert-deftest test-bde-is-member-function-declaration-basic-default-delete-1 ()
+  (let ((tst (make-test-case :input "void foo() = default delete;")))
+    (should (not (with-test-case-return tst (bde-is-member-function-declaration))))))
+
+(ert-deftest test-bde-is-member-function-declaration-basic-default-delete-2 ()
+  (let ((tst (make-test-case :input "void foo() = default = delete;")))
+    (should (not (with-test-case-return tst (bde-is-member-function-declaration))))))
+
+(ert-deftest test-bde-is-member-function-declaration-basic-bsl-delete-1 ()
+  (let ((tst (make-test-case :input "void foo() BSLS_CPP11_DELETED;")))
+    (should (with-test-case-return tst (bde-is-member-function-declaration)))))
+
+(ert-deftest test-bde-is-member-function-declaration-basic-bsl-delete-2 ()
+  (let ((tst (make-test-case :input "void foo() BSLS_CPP11_DELETED ;")))
+    (should (with-test-case-return tst (bde-is-member-function-declaration)))))
+
+(ert-deftest test-bde-is-member-function-declaration-basic-bsl-default-1 ()
+  (let ((tst (make-test-case :input "void foo() BSLS_CPP11_DEFAULT;")))
+    (should (with-test-case-return tst (bde-is-member-function-declaration)))))
+
+(ert-deftest test-bde-is-member-function-declaration-basic-bsl-default-2 ()
+  (let ((tst (make-test-case :input "void foo() BSLS_CPP11_DEFAULT ;")))
+    (should (with-test-case-return tst (bde-is-member-function-declaration)))))
+
+(ert-deftest test-bde-is-member-function-declaration-basic-bsl-default-deleted-1 ()
+  (let ((tst (make-test-case :input "void foo() BSLS_CPP11_DEFAULT BSLS_CPP11_DELETED;")))
+    (should (not (with-test-case-return tst (bde-is-member-function-declaration))))))
+
+(ert-deftest test-bde-is-member-function-declaration-basic-override-1 ()
+  (let ((tst (make-test-case :input "void foo() override;")))
+    (should (with-test-case-return tst (bde-is-member-function-declaration)))))
+
+(ert-deftest test-bde-is-member-function-declaration-basic-override-2 ()
+  (let ((tst (make-test-case :input "void foo()  override ;")))
+    (should (with-test-case-return tst (bde-is-member-function-declaration)))))
+
+(ert-deftest test-bde-is-member-function-declaration-basic-override-3 ()
+  (let ((tst (make-test-case :input "void foo() override; ")))
+    (should (with-test-case-return tst (bde-is-member-function-declaration)))))
+
+(ert-deftest test-bde-is-member-function-declaration-basic-override-4 ()
+  (let ((tst (make-test-case :input "void foo() override")))
+    (should (not (with-test-case-return tst (bde-is-member-function-declaration))))))
+
+(ert-deftest test-bde-is-member-function-declaration-basic-override-5 ()
+  (let ((tst (make-test-case :input "void foo() deleted override;")))
+    (should (not (with-test-case-return tst (bde-is-member-function-declaration))))))
+
+(ert-deftest test-bde-is-member-function-declaration-basic-override-6 ()
+  (let ((tst (make-test-case :input "void foo() default override;")))
+    (should (not (with-test-case-return tst (bde-is-member-function-declaration))))))
+
+(ert-deftest test-bde-is-member-function-declaration-basic-bsl-override-1 ()
+  (let ((tst (make-test-case :input "void foo() BSLS_CPP11_OVERRIDE;")))
+    (should (with-test-case-return tst (bde-is-member-function-declaration)))))
+
+(ert-deftest test-bde-is-member-function-declaration-basic-bsl-override-2 ()
+  (let ((tst (make-test-case :input "void foo() BSLS_CPP11_OVERRIDE ;")))
+    (should (with-test-case-return tst (bde-is-member-function-declaration)))))
+
+(ert-deftest test-bde-is-member-function-declaration-basic-bsl-override-3 ()
+  (let ((tst (make-test-case :input "void foo() BSLS_CPP11_OVERRIDE; ")))
+    (should (with-test-case-return tst (bde-is-member-function-declaration)))))
+
+(ert-deftest test-bde-is-member-function-declaration-basic-bsl-override-4 ()
+  (let ((tst (make-test-case :input "void foo() BSLS_CPP11_OVERRIDE")))
+    (should (not (with-test-case-return tst (bde-is-member-function-declaration))))))
+
+(ert-deftest test-bde-is-member-function-declaration-basic-bsl-override-5 ()
+  (let ((tst (make-test-case :input "void foo() BSLS_CPP11_DELETED BSLS_CPP11_OVERRIDE;")))
+    (should (not (with-test-case-return tst (bde-is-member-function-declaration))))))
+
+(ert-deftest test-bde-is-member-function-declaration-basic-bsl-override-6 ()
+  (let ((tst (make-test-case :input "void foo() BSLS_CPP11_DEFAULT BSLS_CPP11_OVERRIDE;")))
+    (should (not (with-test-case-return tst (bde-is-member-function-declaration))))))
+
+(ert-deftest test-bde-is-member-function-declaration-basic-noexcept-1 ()
+  (let ((tst (make-test-case :input "void foo() noexcept;")))
+    (should (with-test-case-return tst (bde-is-member-function-declaration)))))
+
+(ert-deftest test-bde-is-member-function-declaration-basic-noexcept-2 ()
+  (let ((tst (make-test-case :input "void foo() noexcept ;")))
+    (should (with-test-case-return tst (bde-is-member-function-declaration)))))
+
+(ert-deftest test-bde-is-member-function-declaration-basic-noexcept-3 ()
+  (let ((tst (make-test-case :input "void foo() noexcept; ")))
+    (should (with-test-case-return tst (bde-is-member-function-declaration)))))
+
+(ert-deftest test-bde-is-member-function-declaration-basic-noexcept-4 ()
+  (let ((tst (make-test-case :input "void foo() noexcept")))
+    (should (not (with-test-case-return tst (bde-is-member-function-declaration))))))
+
+(ert-deftest test-bde-is-member-function-declaration-basic-noexcept-5 ()
+  (let ((tst (make-test-case :input "void foo() noexcept = delete;")))
+    (should (with-test-case-return tst (bde-is-member-function-declaration)))))
+
+(ert-deftest test-bde-is-member-function-declaration-basic-noexcept-6 ()
+  (let ((tst (make-test-case :input "void foo() noexcept = default;")))
+    (should (with-test-case-return tst (bde-is-member-function-declaration)))))
+
+(ert-deftest test-bde-is-member-function-declaration-basic-bsl-noexcept-1 ()
+  (let ((tst (make-test-case :input "void foo() BSLS_CPP11_NOEXCEPT;")))
+    (should (with-test-case-return tst (bde-is-member-function-declaration)))))
+
+(ert-deftest test-bde-is-member-function-declaration-basic-bsl-noexcept-2 ()
+  (let ((tst (make-test-case :input "void foo() BSLS_CPP11_NOEXCEPT ;")))
+    (should (with-test-case-return tst (bde-is-member-function-declaration)))))
+
+(ert-deftest test-bde-is-member-function-declaration-basic-bsl-noexcept-3 ()
+  (let ((tst (make-test-case :input "void foo() BSLS_CPP11_NOEXCEPT; ")))
+    (should (with-test-case-return tst (bde-is-member-function-declaration)))))
+
+(ert-deftest test-bde-is-member-function-declaration-basic-bsl-noexcept-4 ()
+  (let ((tst (make-test-case :input "void foo() BSLS_CPP11_NOEXCEPT")))
+    (should (not (with-test-case-return tst (bde-is-member-function-declaration))))))
+
+(ert-deftest test-bde-is-member-function-declaration-basic-bsl-noexcept-5 ()
+  (let ((tst (make-test-case :input "void foo() BSLS_CPP11_NOEXCEPT BSLS_CPP11_DELETED;")))
+    (should (with-test-case-return tst (bde-is-member-function-declaration)))))
+
+(ert-deftest test-bde-is-member-function-declaration-basic-bsl-noexcept-6 ()
+  (let ((tst (make-test-case :input "void foo() BSLS_CPP11_NOEXCEPT BSLS_CPP11_DEFAULT;")))
+    (should (with-test-case-return tst (bde-is-member-function-declaration)))))
+
+(ert-deftest test-bde-is-member-function-declaration-c-noexcept-1 ()
+  (let ((tst (make-test-case :input "void foo() const noexcept;")))
+    (should (with-test-case-return tst (bde-is-member-function-declaration)))))
+
+(ert-deftest test-bde-is-member-function-declaration-c-noexcept-2 ()
+  (let ((tst (make-test-case :input "void foo() const noexcept ;")))
+    (should (with-test-case-return tst (bde-is-member-function-declaration)))))
+
+(ert-deftest test-bde-is-member-function-declaration-c-noexcept-3 ()
+  (let ((tst (make-test-case :input "void foo() const noexcept; ")))
+    (should (with-test-case-return tst (bde-is-member-function-declaration)))))
+
+(ert-deftest test-bde-is-member-function-declaration-c-noexcept-4 ()
+  (let ((tst (make-test-case :input "void foo() const noexcept")))
+    (should (not (with-test-case-return tst (bde-is-member-function-declaration))))))
+
+(ert-deftest test-bde-is-member-function-declaration-c-noexcept-5 ()
+  (let ((tst (make-test-case :input "void foo() const noexcept = delete;")))
+    (should (with-test-case-return tst (bde-is-member-function-declaration)))))
+
+(ert-deftest test-bde-is-member-function-declaration-c-noexcept-6 ()
+  (let ((tst (make-test-case :input "void foo() const noexcept = default;")))
+    (should (with-test-case-return tst (bde-is-member-function-declaration)))))
+
+(ert-deftest test-bde-is-member-function-declaration-c-bsl-noexcept-1 ()
+  (let ((tst (make-test-case :input "void foo() const BSLS_CPP11_NOEXCEPT;")))
+    (should (with-test-case-return tst (bde-is-member-function-declaration)))))
+
+(ert-deftest test-bde-is-member-function-declaration-c-bsl-noexcept-2 ()
+  (let ((tst (make-test-case :input "void foo() const BSLS_CPP11_NOEXCEPT ;")))
+    (should (with-test-case-return tst (bde-is-member-function-declaration)))))
+
+(ert-deftest test-bde-is-member-function-declaration-c-bsl-noexcept-3 ()
+  (let ((tst (make-test-case :input "void foo() const BSLS_CPP11_NOEXCEPT; ")))
+    (should (with-test-case-return tst (bde-is-member-function-declaration)))))
+
+(ert-deftest test-bde-is-member-function-declaration-c-bsl-noexcept-4 ()
+  (let ((tst (make-test-case :input "void foo() const BSLS_CPP11_NOEXCEPT")))
+    (should (not (with-test-case-return tst (bde-is-member-function-declaration))))))
+
+(ert-deftest test-bde-is-member-function-declaration-c-bsl-noexcept-5 ()
+  (let ((tst (make-test-case :input "void foo() const BSLS_CPP11_NOEXCEPT BSLS_CPP11_DELETED;")))
+    (should (with-test-case-return tst (bde-is-member-function-declaration)))))
+
+(ert-deftest test-bde-is-member-function-declaration-c-bsl-noexcept-6 ()
+  (let ((tst (make-test-case :input "void foo() const BSLS_CPP11_NOEXCEPT BSLS_CPP11_DEFAULT;")))
+    (should (with-test-case-return tst (bde-is-member-function-declaration)))))
+
+(ert-deftest test-bde-is-member-function-declaration-ref-1 ()
+  (let ((tst (make-test-case :input "void foo() &;")))
+    (should (with-test-case-return tst (bde-is-member-function-declaration)))))
+
+(ert-deftest test-bde-is-member-function-declaration-ref-2 ()
+  (let ((tst (make-test-case :input "void foo() & ;")))
+    (should (with-test-case-return tst (bde-is-member-function-declaration)))))
+
+(ert-deftest test-bde-is-member-function-declaration-ref-3 ()
+  (let ((tst (make-test-case :input "void foo() &&; ")))
+    (should (with-test-case-return tst (bde-is-member-function-declaration)))))
+
+(ert-deftest test-bde-is-member-function-declaration-ref-4 ()
+  (let ((tst (make-test-case :input "void foo() && ;")))
+    (should (with-test-case-return tst (bde-is-member-function-declaration)))))
+
+(ert-deftest test-bde-is-member-function-declaration-ref-5 ()
+  (let ((tst (make-test-case :input "void foo() &")))
+    (should (not (with-test-case-return tst (bde-is-member-function-declaration))))))
+
+(ert-deftest test-bde-is-member-function-declaration-ref-6 ()
+  (let ((tst (make-test-case :input "void foo() &&")))
+    (should (not (with-test-case-return tst (bde-is-member-function-declaration))))))
+
+(ert-deftest test-bde-is-member-function-declaration-ref-7 ()
+  (let ((tst (make-test-case :input "void foo() &&&;")))
+    (should (not (with-test-case-return tst (bde-is-member-function-declaration))))))
 
 ;; Local Variables:
 ;; no-byte-compile: t


### PR DESCRIPTION
It should enable support for modern c++, however there are some caveats:

- full c++11 syntax is not supported (i.e. no support for `noexcept' operator,
  nor for trailing return types),
- it is probably to permissive (errors should be caught by a compiler anyway),
- it requires certain order of key words,
- it doesn't support `final' keyword.

Yet it should be more helpful with BDE style member function comments.