### PR TITLE
Suppress `iwyu-mode` in `nlinum`

### DIFF
--- a/modules/init-linum.el
+++ b/modules/init-linum.el
@@ -63,6 +63,7 @@
            shell-mode
            help-mode
            compilation-mode
+           iwyu-mode
            Info-mode
            calendar-mode
            project-explorer-mode


### PR DESCRIPTION
It's a compilation mode after all and line numbers there are
excessive.