### PR TITLE
Make backtick an electric pair in markdown mode

### DIFF
--- a/modules/init-markdown.el
+++ b/modules/init-markdown.el
@@ -51,6 +51,16 @@
   (define-key markdown-mode-map (kbd "M-p") #'ace-window))
 
 
+;;; Make backtick an electric pair
+(when exordium-enable-electric-pair-mode
+  (add-hook 'markdown-mode-hook
+            '(lambda ()
+               (setq-local electric-pair-pairs
+                           (append electric-pair-pairs '((?` . ?`))))
+               (setq-local electric-pair-text-pairs
+                           (append electric-pair-text-pairs '((?` . ?`)))))))
+
+
 ;;; Impatient markdown mode
 
 (require 'impatient-mode)


### PR DESCRIPTION
electric-pair is pretty addictive when (ab)used on blocks of text.
And selecting a command in markdown, then hitting a backtick key
only to realise the next thing to do is to hit `C-z` wasn't a good
experience to me.