### PR TITLE
Limit range and align default values in `bde-align-fundecl`

### DIFF
--- a/modules/init-bde-style.el
+++ b/modules/init-bde-style.el
@@ -47,7 +47,6 @@
 ;;;             const bsl::vector<int>&                accounts,
 ;;;             int                                    id,
 ;;;             BloombergLP::bslma::Allocator         *basicAllocator = 0);
-;;; TODO: apparently default values should be aligned too.
 ;;;
 ;;; `bde-align-funcall': align function call arguments
 ;;; Before (cursor must be inside the argument list):
@@ -693,7 +692,8 @@ according to the BDE style."
   (let ((args (exordium-bde-split-arglist (thing-at-point 'arglist t)))
         (parsed-args ())
         (max-type-length 0)
-        (max-stars 0))
+        (max-stars 0)
+        (max-var-length 0))
     (when args
       ;; Parse each argument and get the max type length
       (setq parsed-args
@@ -702,7 +702,10 @@ according to the BDE style."
                          (setq max-type-length (max max-type-length
                                                     (length (car parsed-arg)))
                                max-stars (max max-stars
-                                              (caddr parsed-arg)))
+                                              (caddr parsed-arg))
+                               max-var-length (max max-var-length
+                                                   (- (length (cadr parsed-arg))
+                                                      (caddr parsed-arg))))
                          parsed-arg))
                     args))
       (funcall '(lambda (bounds)
@@ -727,7 +730,11 @@ according to the BDE style."
                                       ?\s)))
                (insert var)
                (when assign
-                 (insert " " assign)))
+                 (insert (make-string (+ (- max-var-length
+                                            (- (length var) num-stars))
+                                         1) ; at least one space
+                                      ?\s))
+                 (insert assign)))
              (unless (>= i (length parsed-args))
                (insert ",")
                (newline))

--- a/modules/init-bde-style.t.el
+++ b/modules/init-bde-style.t.el
@@ -111,15 +111,15 @@ is selected or not. Return the body return value."
 (ert-deftest test-bde-align-fundecl-1 ()
   (let ((tst (make-test-case :input "struct A {
     void foo(std::vector<int>& a = {1, 2, 3},
-             std::map<int, int> &b = std::vector(2,2),
+             std::map<int, int> &bb = std::vector(2,2),
              std::vector<int>* c = std::vector{1, 2, 3},
              std::map<int, int> *d = std::map<int, int>{});
 };"
                              :output "struct A {
-    void foo(std::vector<int>&    a = {1, 2, 3},
-             std::map<int, int>&  b = std::vector(2,2),
-             std::vector<int>    *c = std::vector{1, 2, 3},
-             std::map<int, int>  *d = std::map<int, int>{});
+    void foo(std::vector<int>&    a  = {1, 2, 3},
+             std::map<int, int>&  bb = std::vector(2,2),
+             std::vector<int>    *c  = std::vector{1, 2, 3},
+             std::map<int, int>  *d  = std::map<int, int>{});
 };"
                              :cursor-pos (1+ (length "struct A {")))))
     (should (string= (with-test-case-output tst (bde-align-fundecl))
@@ -130,13 +130,13 @@ is selected or not. Return the body return value."
     void foo(std::vector<int>& a = {1, 2, 3},
              std::map<int, int> &b = std::vector(2,2),
              std::vector<int>* c = std::vector{1, 2, 3},
-             std::map<int, int> *d = std::map<int, int>{});
+             std::map<int, int> **dd = std::map<int, int>{});
 };"
                              :output "struct A {
-    void foo(std::vector<int>&    a = {1, 2, 3},
-             std::map<int, int>&  b = std::vector(2,2),
-             std::vector<int>    *c = std::vector{1, 2, 3},
-             std::map<int, int>  *d = std::map<int, int>{});
+    void foo(std::vector<int>&     a  = {1, 2, 3},
+             std::map<int, int>&   b  = std::vector(2,2),
+             std::vector<int>     *c  = std::vector{1, 2, 3},
+             std::map<int, int>  **dd = std::map<int, int>{});
 };"
                              :cursor-pos (+ 11 (length "struct A {")))))
     (should (string= (with-test-case-output tst (bde-align-fundecl))
@@ -144,16 +144,16 @@ is selected or not. Return the body return value."
 
 (ert-deftest test-bde-align-fundecl-3 ()
   (let ((tst (make-test-case :input "struct A {
-    void foo(std::vector<int>& a = {1, 2, 3},
+    void foo(std::vector<int>& aa = {1, 2, 3},
              std::map<int, int> &b = std::vector(2,2),
              std::vector<int>* c = std::vector{1, 2, 3},
              std::map<int, int> *d = std::map<int, int>{});
 };"
                              :output "struct A {
-    void foo(std::vector<int>&    a = {1, 2, 3},
-             std::map<int, int>&  b = std::vector(2,2),
-             std::vector<int>    *c = std::vector{1, 2, 3},
-             std::map<int, int>  *d = std::map<int, int>{});
+    void foo(std::vector<int>&    aa = {1, 2, 3},
+             std::map<int, int>&  b  = std::vector(2,2),
+             std::vector<int>    *c  = std::vector{1, 2, 3},
+             std::map<int, int>  *d  = std::map<int, int>{});
 };"
                              :cursor-pos (+ 200 (length "struct A {")))))
     (should (string= (with-test-case-output tst (bde-align-fundecl))
@@ -162,16 +162,16 @@ is selected or not. Return the body return value."
 (ert-deftest test-bde-align-fundecl-long-1 ()
   (let ((tst (make-test-case :input "struct A {
     void foo_is_a_long_name_so_parameters_will_not_fit(std::vector<int>& a = {1, 2, 3},
-             std::map<int, int> &b = std::vector(2,2),
+             std::map<int, int> &bb = std::vector(2,2),
              std::vector<int>* c = std::vector{1, 2, 3},
              std::map<int, int> *d = std::map<int, int>{});
 };"
                              :output "struct A {
     void foo_is_a_long_name_so_parameters_will_not_fit(
-                                std::vector<int>&    a = {1, 2, 3},
-                                std::map<int, int>&  b = std::vector(2,2),
-                                std::vector<int>    *c = std::vector{1, 2, 3},
-                                std::map<int, int>  *d = std::map<int, int>{});
+                               std::vector<int>&    a  = {1, 2, 3},
+                               std::map<int, int>&  bb = std::vector(2,2),
+                               std::vector<int>    *c  = std::vector{1, 2, 3},
+                               std::map<int, int>  *d  = std::map<int, int>{});
 };"
                              :cursor-pos (1+ (length "struct A {")))))
     (should (string= (with-test-case-output tst (bde-align-fundecl))
@@ -183,14 +183,14 @@ is selected or not. Return the body return value."
 std::vector<int>& a = {1, 2, 3},
 std::map<int, int> &b = std::vector(2,2),
 std::vector<int>* c = std::vector{1, 2, 3},
-std::map<int, int> *d = std::map<int, int>{});
+std::map<int, int> **dd = std::map<int, int>{});
 };"
                              :output "struct A {
     void foo_is_a_long_name_so_parameters_will_not_fit(
-                                std::vector<int>&    a = {1, 2, 3},
-                                std::map<int, int>&  b = std::vector(2,2),
-                                std::vector<int>    *c = std::vector{1, 2, 3},
-                                std::map<int, int>  *d = std::map<int, int>{});
+                              std::vector<int>&     a  = {1, 2, 3},
+                              std::map<int, int>&   b  = std::vector(2,2),
+                              std::vector<int>     *c  = std::vector{1, 2, 3},
+                              std::map<int, int>  **dd = std::map<int, int>{});
 };"
                              :cursor-pos (+ 80 (length "struct A {")))))
     (should (string= (with-test-case-output tst (bde-align-fundecl))
@@ -198,17 +198,17 @@ std::map<int, int> *d = std::map<int, int>{});
 
 (ert-deftest test-bde-align-fundecl-long-3 ()
   (let ((tst (make-test-case :input "struct A {
-    void foo_is_a_long_name_so_parameters_will_not_fit(std::vector<int>& a = {1, 2, 3},
+    void foo_is_a_long_name_so_parameters_will_not_fit(std::vector<int>& aa = {1, 2, 3},
                                                        std::map<int, int> &b = std::vector(2,2),
                                                        std::vector<int>* c = std::vector{1, 2, 3},
                                                        std::map<int, int> *d = std::map<int, int>{});
 };"
                              :output "struct A {
     void foo_is_a_long_name_so_parameters_will_not_fit(
-                                std::vector<int>&    a = {1, 2, 3},
-                                std::map<int, int>&  b = std::vector(2,2),
-                                std::vector<int>    *c = std::vector{1, 2, 3},
-                                std::map<int, int>  *d = std::map<int, int>{});
+                               std::vector<int>&    aa = {1, 2, 3},
+                               std::map<int, int>&  b  = std::vector(2,2),
+                               std::vector<int>    *c  = std::vector{1, 2, 3},
+                               std::map<int, int>  *d  = std::map<int, int>{});
 };"
                              :cursor-pos (+ 200 (length "struct A {")))))
     (should (string= (with-test-case-output tst (bde-align-fundecl))

--- a/modules/init-bde-style.t.el
+++ b/modules/init-bde-style.t.el
@@ -1207,6 +1207,29 @@ class TheName {")))
     (should (equal (with-test-case-return tst (exordium-bde-bounds-of-arglist-at-point))
                    (cons 24 388)))))
 
+(ert-deftest test-exordium-bde-bounds-of-arglist-at-point-too-long-function ()
+  (let ((tst (make-test-case :input (concat "struct A {
+    void f"
+
+                                            (make-string (* 80 25) ?o)
+                                            "(bool b,
+        int c);
+};")
+                             :cursor-pos (1+ (length "struct A {
+    void f")))))
+    (should-not (with-test-case-return tst (exordium-bde-bounds-of-arglist-at-point)))))
+
+(ert-deftest test-exordium-bde-bounds-of-arglist-at-point-too-long-args ()
+  (let ((tst (make-test-case :input (concat "struct A {
+    void foo(b"
+                                            (make-string (* 80 25) ?o)
+                                            "l b,
+        int c);
+};")
+                             :cursor-pos (1+ (length "struct A {
+    void foo(b")))))
+    (should-not (with-test-case-return tst (exordium-bde-bounds-of-arglist-at-point)))))
+
 ;; Local Variables:
 ;; no-byte-compile: t
 ;; End:


### PR DESCRIPTION
Two improvements to `bde-align-fundecl`:

- limit searching for open and close params to 4000 characters
- align default values