### PR TITLE
Diminish modern-c++-font-lock-mode

### DIFF
--- a/modules/init-cpp.el
+++ b/modules/init-cpp.el
@@ -163,7 +163,9 @@
                 (font-lock-add-keywords nil exordium-extra-c++-keywords))
             t))
 (when (eq exordium-enable-c++11-keywords :modern)
-  (add-hook 'c++-mode-hook #'modern-c++-font-lock-mode))
+  (add-hook 'c++-mode-hook (lambda ()
+                             (modern-c++-font-lock-mode)
+                             (diminish 'modern-c++-font-lock-mode))))
 
 
 (provide 'init-cpp)


### PR DESCRIPTION
I think I didn't know about `diminish` when I added the
`modern-c++-font-lock-mode`. Yet when we use `legacy` mode it doesn't taint
the mode line. On top of that `mc++fl` doesn't even give any extra
functionality there.