### PR TITLE
Truly use helm everywhere

### DIFF
--- a/modules/init-helm.el
+++ b/modules/init-helm.el
@@ -23,10 +23,11 @@
 (global-set-key (kbd "C-S-a") 'helm-projectile-ag)
 
 (when exordium-helm-everywhere
+  (helm-mode)
+  (diminish 'helm-mode)
   (global-set-key (kbd "M-x") 'helm-M-x)
   (global-set-key (kbd "C-x C-f") 'helm-find-files)
-  (global-set-key (kbd "M-y") 'helm-show-kill-ring)
-  (global-set-key (kbd "C-x b") 'helm-mini))
+  (global-set-key (kbd "M-y") 'helm-show-kill-ring))
 
 (when exordium-helm-fuzzy-match
   (setq helm-M-x-fuzzy-match t

--- a/modules/init-ido.el
+++ b/modules/init-ido.el
@@ -6,7 +6,8 @@
 ;;; C-x C-r        Open recent file with IDO or Helm.
 
 (require 'ido)
-(ido-mode 'both)
+(unless exordium-helm-everywhere
+  (ido-mode 'both))
 
 
 ;; Ignored files and buffers


### PR DESCRIPTION
Most noticeable, at least for me, was `ido` under `C-x C-w` and `C-x i`.
Now `helm` works under `magit` as well, just try `b c`.