### PR TITLE
 Refactor line numbers

### DIFF
--- a/modules/init-linum.el
+++ b/modules/init-linum.el
@@ -25,6 +25,18 @@
     (set-window-margins nil (if nlinum-mode width)
                         (cdr (window-margins)))))
 
+(defun exordium-inhibit-line-numbers-p ()
+  (or (cl-member major-mode exordium-inhibit-line-numbers-modes)
+      (and exordium-inhibit-line-numbers-star-buffers
+           (eq 0 (string-match "*" (buffer-name))))
+      (> (buffer-size) exordium-inhibit-line-numbers-buffer-size)))
+
+;;;###autoload
+(define-globalized-minor-mode exordium-global-nlinum-mode nlinum-mode
+  (lambda () (unless (or (minibufferp)
+                         (exordium-inhibit-line-numbers-p))
+               (nlinum-mode))))
+
 (cond ((and (fboundp 'global-nlinum-mode)
             (eq exordium-display-line-numbers :nlinum))
        ;; Use nlinum - a lazy, faster mode for line numbers
@@ -40,8 +52,8 @@
        (let ((h (face-attribute 'default :height)))
          (set-face-attribute 'linum nil :height h))
        ;;
-       ;; Turn on nlinum
-       (global-nlinum-mode t))
+
+       (exordium-global-nlinum-mode t))
 
       ((and (fboundp 'global-linum-mode)
             (eq exordium-display-line-numbers t))
@@ -56,25 +68,10 @@
        ;;
        ;; Turn on linum
        (global-linum-mode t)
-       ;;
-       ;; Do not enable linum for specific modes
-       (defvar linum-mode-inhibit-modes-list
-         '(eshell-mode
-           shell-mode
-           help-mode
-           compilation-mode
-           iwyu-mode
-           Info-mode
-           calendar-mode
-           treemacs-mode
-           org-mode
-           rtags-rdm-mode
-           rtags-diagnostics-mode
-           eww-mode)
-         "List of modes for which we DO NOT want line numbers")
+
        (defadvice linum-on (around linum-on-inhibit-for-modes)
          "Stop the load of linum-mode for some major modes."
-         (unless (member major-mode linum-mode-inhibit-modes-list)
+         (unless (exordium-inhibit-line-numbers-p)
            ad-do-it))
        (ad-activate 'linum-on)))
 

--- a/modules/init-linum.el
+++ b/modules/init-linum.el
@@ -47,11 +47,6 @@
            ;; "*ERROR*: Invalid face: linum".  See
            ;; http://lists.gnu.org/archive/html/bug-gnu-emacs/2015-01/msg00079.html
            (fset 'nlinum--setup-window 'nlinum--setup-window-fudge)))
-       ;;
-       ;; Make line numbers display correctly when user zooms with C-+/C--
-       (let ((h (face-attribute 'default :height)))
-         (set-face-attribute 'linum nil :height h))
-       ;;
 
        (exordium-global-nlinum-mode t))
 

--- a/modules/init-linum.el
+++ b/modules/init-linum.el
@@ -26,10 +26,12 @@
                         (cdr (window-margins)))))
 
 (defun exordium-inhibit-line-numbers-p ()
-  (or (cl-member major-mode exordium-inhibit-line-numbers-modes)
+  (or (and exordium-inhibit-line-numbers-modes
+           (cl-member major-mode exordium-inhibit-line-numbers-modes))
       (and exordium-inhibit-line-numbers-star-buffers
            (eq 0 (string-match "*" (buffer-name))))
-      (> (buffer-size) exordium-inhibit-line-numbers-buffer-size)))
+      (and exordium-inhibit-line-numbers-buffer-size
+           (> (buffer-size) exordium-inhibit-line-numbers-buffer-size))))
 
 ;;;###autoload
 (define-globalized-minor-mode exordium-global-nlinum-mode nlinum-mode

--- a/modules/init-prefs.el
+++ b/modules/init-prefs.el
@@ -160,7 +160,9 @@ Set to `nil' to enable line numbers even in large buffers."
   "Controls whether line numbers shold be displayed in buffers that name
 starts with `*'.
 Set to `t' to don't display line numbers in buffers that name starts with `*'.
-Set to `nil' to display line numbers in buffers that name starts with `*'.")
+Set to `nil' to display line numbers in buffers that name starts with `*'."
+  :group 'exordium
+  :type 'boolean)
 
 
 ;;; Miscellaneous utilities -- see init-util.el

--- a/modules/init-prefs.el
+++ b/modules/init-prefs.el
@@ -150,8 +150,11 @@ line numbers WILL NOT be shown."
   :group 'exordium
   :type 'list)
 
-(defcustom exordium-inhibit-line-numbers-buffer-size (* 80 4000)
+(defcustom exordium-inhibit-line-numbers-buffer-size nil
   "The maximum buffer size that line numbers should be displayed.
+Set to some integer, to show line numbers only for buffers that are smaller
+than the specified size. I.e., `(* 512 1024)' will only display line numbers
+that are smaller than 0.5MiB (this is over 6.5k 80 character lines).
 Set to `nil' to enable line numbers even in large buffers."
   :group 'exordium
   :type 'integer)

--- a/modules/init-prefs.el
+++ b/modules/init-prefs.el
@@ -124,9 +124,43 @@ This makes it easier to paste text from the Windows clipboard."
 Set to nil to disable line numbers.
 Set to t or :linum to enable line numbers using package `linum'.
 Set to :nlinum to enable line numbers using pakage `nlinum'
-which should be more efficient in particular for large buffers."
+which should be more efficient in particular for large buffers.
+
+When buffer matches either of the `exordium-inhibit-line-numbers-modes',
+`exordium-inhibit-line-numbers-buffer-size', or `exordium-inhibit-line-numbers-star-buffers'
+line numbers WILL NOT be shown."
   :group 'exordium
   :type  'symbol)
+
+(defcustom exordium-inhibit-line-numbers-modes '(eshell-mode
+                                                 shell-mode
+                                                 help-mode
+                                                 compilation-mode
+                                                 iwyu-mode
+                                                 Info-mode
+                                                 calendar-mode
+                                                 treemacs-mode
+                                                 org-mode
+                                                 rtags-rdm-mode
+                                                 rtags-diagnostics-mode
+                                                 eww-mode
+                                                 dired-mode
+                                                 image-mode)
+  "List of modes for which line numbers should not be displayed."
+  :group 'exordium
+  :type 'list)
+
+(defcustom exordium-inhibit-line-numbers-buffer-size (* 80 4000)
+  "The maximum buffer size that line numbers should be displayed.
+Set to `nil' to enable line numbers even in large buffers."
+  :group 'exordium
+  :type 'integer)
+
+(defcustom exordium-inhibit-line-numbers-star-buffers nil
+  "Controls whether line numbers shold be displayed in buffers that name
+starts with `*'.
+Set to `t' to don't display line numbers in buffers that name starts with `*'.
+Set to `nil' to display line numbers in buffers that name starts with `*'.")
 
 
 ;;; Miscellaneous utilities -- see init-util.el


### PR DESCRIPTION
I admit the hack with defining own custom global mode is not something I'm particularly proud of. I wish there was some better customisation point. However, for now it seems to do the job and `nlinum` (despite its quirks) gives me observable speed difference  over `linum`.

- use custom `exordium-global-nlinum-mode` for common inhibitions
- add inhibition for buffers that name starts with `*`
- add inhibition for large buffers
- remove fix for font size in nlinum when zooming