### PR TITLE
Fix `bde-align-funcdecl` for c-tor with initizlizer list

### DIFF
--- a/modules/init-bde-style.el
+++ b/modules/init-bde-style.el
@@ -514,7 +514,7 @@ Return `nil' when no qualifying parenthesis has been found within the first
 (defun exordium-bde-arglist-at-point--close-paren-position (from)
   "Return the position of the function argument list closing parenthesis. The
 search starts from the `from' position and ends when semicolon, `inline-open',
-`defun-open', or `noexcept' has been encountered.
+`defun-open', `member-init-intro', or `noexcept' has been encountered.
 Return `nil' when no qualifying parenthesis has been found withing the first
 80 (columns) * 25 (lines) characters."
   (when from
@@ -526,14 +526,19 @@ Return `nil' when no qualifying parenthesis has been found withing the first
             (candidate nil))
         (catch 'pos
           (while (re-search-forward (concat "\\(\\()\\)\\|"      ;; 2: )
-                                            "\\({\\)\\|"         ;; 3: {
+                                            "\\({\\|:\\)\\|"     ;; 3: { :
                                             "\\(;\\|noexcept\\|" ;; 4: ; noexcept
                                             "BSLS_CPP11_NOEXCEPT\\)\\)") ;; 4...
                                     bound t)
             (cond ((match-string 2)
                    (setq candidate (point)))
                   ((match-string 3)
-                   (when (cl-member '(inline-open defun-open)
+                   ;; TODO: `member-init-intro' is for initializer list. The
+                   ;; latter could be in `topmost-intro' but simple adding that
+                   ;; breaks more functionality. It would require some support
+                   ;; in `bde-align-funcdecl', i.e., to move initializer list
+                   ;; after the c-tor arguments, before aligning.
+                   (when (cl-member '(inline-open defun-open member-init-intro)
                                     (c-guess-basic-syntax)
                                     :test any-of-is-car-of)
                      (throw 'pos candidate)))

--- a/modules/init-bde-style.t.el
+++ b/modules/init-bde-style.t.el
@@ -780,6 +780,20 @@ class TheName {")))
     (should (equal (with-test-case-return tst (exordium-bde-bounds-of-arglist-at-point))
                    (cons 24 32)))))
 
+(ert-deftest test-exordium-bde-bounds-of-arglist-at-point-simple-5 ()
+  (let ((tst (make-test-case :input "Foo::Foo(bool b)
+: b{b} {}"
+                             :cursor-pos 2)))
+    (should (equal (with-test-case-return tst (exordium-bde-bounds-of-arglist-at-point))
+                   (cons 9 17)))))
+
+(ert-deftest test-exordium-bde-bounds-of-arglist-at-point-simple-6 ()
+  (let ((tst (make-test-case :input "Foo::Foo(bool b)
+: b{b} {}"
+                             :cursor-pos 12)))
+    (should (equal (with-test-case-return tst (exordium-bde-bounds-of-arglist-at-point))
+                   (cons 9 17)))))
+
 (ert-deftest test-exordium-bde-bounds-of-arglist-at-point-multi-arg-1 ()
   (let ((tst (make-test-case :input "struct A {
     void foo(bool b, int c);
@@ -812,6 +826,20 @@ class TheName {")))
     (should (equal (with-test-case-return tst (exordium-bde-bounds-of-arglist-at-point))
                    (cons 24 39)))))
 
+(ert-deftest test-exordium-bde-bounds-of-arglist-at-point-multi-arg-5 ()
+  (let ((tst (make-test-case :input "Foo::Foo(bool b, int c)
+: b{b} {}"
+                             :cursor-pos 2)))
+    (should (equal (with-test-case-return tst (exordium-bde-bounds-of-arglist-at-point))
+                   (cons 9 24)))))
+
+(ert-deftest test-exordium-bde-bounds-of-arglist-at-point-multi-arg-6 ()
+  (let ((tst (make-test-case :input "Foo::Foo(bool b, int c)
+: b{b} {}"
+                             :cursor-pos 11)))
+    (should (equal (with-test-case-return tst (exordium-bde-bounds-of-arglist-at-point))
+                   (cons 9 24)))))
+
 (ert-deftest test-exordium-bde-bounds-of-arglist-at-point-multi-line-1 ()
   (let ((tst (make-test-case :input "struct A {
     void foo(bool b,
@@ -838,6 +866,23 @@ class TheName {")))
                              :cursor-pos (+ 25 (length "struct A {")))))
     (should (equal (with-test-case-return tst (exordium-bde-bounds-of-arglist-at-point))
                    (cons 24 47)))))
+
+(ert-deftest test-exordium-bde-bounds-of-arglist-at-point-multi-line-4 ()
+  (let ((tst (make-test-case :input "Foo::Foo(bool b,
+int c)
+: b{b} {}"
+                             :cursor-pos 2)))
+    (should (equal (with-test-case-return tst (exordium-bde-bounds-of-arglist-at-point))
+                   (cons 9 24)))))
+
+(ert-deftest test-exordium-bde-bounds-of-arglist-at-point-multi-line-4 ()
+  (let ((tst (make-test-case :input "Foo::Foo(bool b,
+int c)
+: b{b} {}"
+                             :cursor-pos 12)))
+    (should (equal (with-test-case-return tst (exordium-bde-bounds-of-arglist-at-point))
+                   (cons 9 24)))))
+
 
 (ert-deftest test-exordium-bde-bounds-of-arglist-at-point-multi-function-1 ()
   (let ((tst (make-test-case :input "struct A {


### PR DESCRIPTION
Not for all possible cases (see the `TODO`), but should be good
for the ones met in the wild.