### PR TITLE
Update gitignore and init-org

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ local
 elpa
 
 # Caches
+.cache/
 cider-history
 semanticdb
 # CEDET's SRecode stores template files in Emacs install dir??
@@ -28,6 +29,7 @@ eshell
 ido.last
 recentf
 project-explorer-cache
+network-security.data
 
 # Desktop State
 .emacs.desktop

--- a/modules/init-org.el
+++ b/modules/init-org.el
@@ -44,7 +44,7 @@
    'org-babel-load-languages
    '((perl       . t)
      (ruby       . t)
-     (sh         . t)
+     (shell      . t)
      (python     . t)
      (emacs-lisp . t)
      (C          . t)


### PR DESCRIPTION
The first one is to accommodate new files while the latter udpates `sh` to `shell` for org-9.1.9