### PR TITLE
Modernize snippets

### DIFF
--- a/doc/snippets.md
+++ b/doc/snippets.md
@@ -17,9 +17,9 @@ bind            | `bdef_BindUtil::bind`
 cerr            | `std::cerr`
 cout            | `std::cout`
 main            | main function
-now             | `bdetu_SystemTime::now`
+now             | `bslmt::SystemTime::nowMonotonicClock`
 return          | return statement
-sleep           | `bcemt_ThreadUtil::sleep`
+sleep           | `bslmt::ThreadUtil::sleep`
 lock            | lock guard
 unlock          | release a lock guard
 

--- a/doc/snippets.md
+++ b/doc/snippets.md
@@ -7,12 +7,12 @@ Usage: type one of the following trigger keywords, and type <kbd>C-c y</kbd>.
 Keyword         | Description
 ----------------|-----------------------------------------------------------
 assert          | `BSLS_ASSERT_OPT`
-cat             | `BAEL_LOG_SET_CATEGORY`
-debug           | `BAEL_LOG_DEBUG`
-error           | `BAEL_LOG_ERROR`
-info            | `BAEL_LOG_INFO`
-trace           | `BAEL_LOG_TRACE`
-warn            | `BAEL_LOG_WARN`
+cat             | `BALL_LOG_SET_CATEGORY`
+debug           | `BALL_LOG_DEBUG`
+error           | `BALL_LOG_ERROR`
+info            | `BALL_LOG_INFO`
+trace           | `BALL_LOG_TRACE`
+warn            | `BALL_LOG_WARN`
 bind            | `bdef_BindUtil::bind`
 cerr            | `std::cerr`
 cout            | `std::cout`

--- a/modules/init-linum.el
+++ b/modules/init-linum.el
@@ -9,6 +9,8 @@
 (require 'linum)
 (require 'nlinum)
 (require 'init-prefs)
+(unless (version< emacs-version "26.1")
+  (require 'display-line-numbers))
 
 (defun nlinum--setup-window-fudge ()
   "Workaround a bug in older versions of Emacs"
@@ -26,18 +28,26 @@
                         (cdr (window-margins)))))
 
 (defun exordium-inhibit-line-numbers-p ()
-  (or (and exordium-inhibit-line-numbers-modes
+  (or (minibufferp)
+      (and exordium-inhibit-line-numbers-modes
            (cl-member major-mode exordium-inhibit-line-numbers-modes))
       (and exordium-inhibit-line-numbers-star-buffers
            (eq 0 (string-match "*" (buffer-name))))
       (and exordium-inhibit-line-numbers-buffer-size
-           (> (buffer-size) exordium-inhibit-line-numbers-buffer-size))))
+           (> (buffer-size) exordium-inhibit-line-numbers-buffer-size))
+      ;; taken from linum.el
+      (and (daemonp) (null (frame-parameter nil 'client)))))
 
 ;;;###autoload
-(define-globalized-minor-mode exordium-global-nlinum-mode nlinum-mode
-  (lambda () (unless (or (minibufferp)
-                         (exordium-inhibit-line-numbers-p))
+(define-globalized-minor-mode exordium-global-nlinum-mode
+  nlinum-mode
+  (lambda () (unless (exordium-inhibit-line-numbers-p)
                (nlinum-mode))))
+;;;###autoload
+(define-globalized-minor-mode exordium-global-display-line-numbers-mode
+  display-line-numbers-mode
+  (lambda () (unless (exordium-inhibit-line-numbers-p)
+              (display-line-numbers-mode))))
 
 (cond ((and (fboundp 'global-nlinum-mode)
             (eq exordium-display-line-numbers :nlinum))
@@ -54,22 +64,27 @@
 
       ((and (fboundp 'global-linum-mode)
             (eq exordium-display-line-numbers t))
-       ;; Use linum - non-lazy mode for line numbers
-       ;;
-       ;; Make line numbers display correctly when user zooms with C-+/C--
-       ;; FIXME: this is broken, just a workaround for now.
-       (when (facep 'linum-highlight-face)
-         (let ((h (face-attribute 'default :height)))
-           (set-face-attribute 'linum nil :height h)
-           (set-face-attribute 'linum-highlight-face nil :height h)))
-       ;;
-       ;; Turn on linum
-       (global-linum-mode t)
+       (let ((min-version "26.1"))
+         (if (version< emacs-version min-version)
+             (progn
+               ;; Use linum - non-lazy mode for line numbers - obsolete in 26.1
+               ;;
+               ;; Make line numbers display correctly when user zooms with C-+/C--
+               ;; FIXME: this is broken, just a workaround for now.
+               (when (facep 'linum-highlight-face)
+                 (let ((h (face-attribute 'default :height)))
+                   (set-face-attribute 'linum nil :height h)
+                   (set-face-attribute 'linum-highlight-face nil :height h)))
+               ;;
+               ;; Turn on linum
+               (global-linum-mode t)
 
-       (defadvice linum-on (around linum-on-inhibit-for-modes)
-         "Stop the load of linum-mode for some major modes."
-         (unless (exordium-inhibit-line-numbers-p)
-           ad-do-it))
-       (ad-activate 'linum-on)))
+               (defadvice linum-on (around linum-on-inhibit-for-modes)
+                 "Stop the load of linum-mode for some major modes."
+                 (unless (exordium-inhibit-line-numbers-p)
+                   ad-do-it))
+               (ad-activate 'linum-on))
+           ;; Use display-line-numbers-mode
+           (exordium-global-display-line-numbers-mode t)))))
 
 (provide 'init-linum)

--- a/modules/init-org.el
+++ b/modules/init-org.el
@@ -42,9 +42,11 @@
   ;; Enable org-babel for perl, ruby, sh, python, emacs-lisp, C, C++, etc
   (org-babel-do-load-languages
    'org-babel-load-languages
-   '((perl       . t)
+   `((perl       . t)
      (ruby       . t)
-     (shell      . t)
+     ,(if (version< org-version "9.0")
+         '(sh         . t)
+       '(shell      . t))
      (python     . t)
      (emacs-lisp . t)
      (C          . t)

--- a/modules/init-prefs.el
+++ b/modules/init-prefs.el
@@ -122,7 +122,7 @@ This makes it easier to paste text from the Windows clipboard."
 (defcustom exordium-display-line-numbers t
   "Whether line numbers are displayed or not.
 Set to nil to disable line numbers.
-Set to t or :linum to enable line numbers using package `linum'.
+Set to `t' to enable line numbers using `line-numbers' (or `linum' on pre 26.1 emacs).
 Set to :nlinum to enable line numbers using pakage `nlinum'
 which should be more efficient in particular for large buffers.
 

--- a/snippets/c++-mode/bael_warn
+++ b/snippets/c++-mode/bael_warn
@@ -1,6 +1,0 @@
-# -*- mode: snippet; require-final-newline: nil -*-
-# name: BAEL WARN
-# key: warn
-# binding: direct-keybinding
-# --
-BAEL_LOG_WARN << "$0" << BAEL_LOG_END;

--- a/snippets/c++-mode/ball_category
+++ b/snippets/c++-mode/ball_category
@@ -1,6 +1,6 @@
 # -*- mode: snippet; require-final-newline: nil -*-
-# name: BAEL TRACE
-# key: trace
+# name: BALL SET CATEGORY
+# key: cat
 # binding: direct-keybinding
 # --
-BAEL_LOG_TRACE << "$0" << BAEL_LOG_END;
+BALL_LOG_SET_CATEGORY(k_LOG_CATEGORY);

--- a/snippets/c++-mode/ball_debug
+++ b/snippets/c++-mode/ball_debug
@@ -1,6 +1,6 @@
 # -*- mode: snippet; require-final-newline: nil -*-
-# name: BAEL SET CATEGORY
-# key: cat
+# name: BALL DEBUG
+# key: debug
 # binding: direct-keybinding
 # --
-BAEL_LOG_SET_CATEGORY(k_LOG_CATEGORY);
+BALL_LOG_DEBUG << "$0";

--- a/snippets/c++-mode/ball_error
+++ b/snippets/c++-mode/ball_error
@@ -1,6 +1,6 @@
 # -*- mode: snippet; require-final-newline: nil -*-
-# name: BAEL DEBUG
-# key: debug
+# name: BALL ERROR
+# key: error
 # binding: direct-keybinding
 # --
-BAEL_LOG_DEBUG << "$0" << BAEL_LOG_END;
+BALL_LOG_ERROR << "$0";

--- a/snippets/c++-mode/ball_info
+++ b/snippets/c++-mode/ball_info
@@ -1,0 +1,6 @@
+# -*- mode: snippet; require-final-newline: nil -*-
+# name: BALL INFO
+# key: info
+# binding: direct-keybindin
+# --
+BALL_LOG_INFO << "$0";

--- a/snippets/c++-mode/ball_trace
+++ b/snippets/c++-mode/ball_trace
@@ -1,6 +1,6 @@
 # -*- mode: snippet; require-final-newline: nil -*-
-# name: BAEL INFO
-# key: info
+# name: BALL TRACE
+# key: trace
 # binding: direct-keybinding
 # --
-BAEL_LOG_INFO << "$0" << BAEL_LOG_END;
+BALL_LOG_TRACE << "$0";

--- a/snippets/c++-mode/ball_warn
+++ b/snippets/c++-mode/ball_warn
@@ -1,6 +1,6 @@
 # -*- mode: snippet; require-final-newline: nil -*-
-# name: BAEL ERROR
-# key: error
+# name: BALL WARN
+# key: warn
 # binding: direct-keybinding
 # --
-BAEL_LOG_ERROR << "$0" << BAEL_LOG_END;
+BALL_LOG_WARN << "$0";

--- a/snippets/c++-mode/implementation
+++ b/snippets/c++-mode/implementation
@@ -19,7 +19,7 @@
 
 ;; Namespaces
 (let ((package-name (bde-package-name)))
-  (insert "#include <bael_log.h>
+  (insert "#include <ball_log.h>
 
 namespace BloombergLP {
 namespace " package-name " {

--- a/snippets/c++-mode/locked
+++ b/snippets/c++-mode/locked
@@ -6,7 +6,7 @@
 # --
 (end-of-line)
 (save-excursion
-  (insert "BCEMT_MUTEXASSERT_IS_LOCKED(&d_mutex);")
+  (insert "BSLMT_MUTEXASSERT_IS_LOCKED(&d_mutex);")
   (end-of-line)
   (dotimes (i (- 70 (current-column)))
   (insert " "))

--- a/snippets/c++-mode/now
+++ b/snippets/c++-mode/now
@@ -3,4 +3,4 @@
 # key: now
 # binding: direct-keybinding
 # --
-bdet_TimeInterval now = bdetu_SystemTime::now();
+bslmt::TimeInterval now = bsls::SystemTime::nowMonotonicClock();

--- a/snippets/c++-mode/sleep
+++ b/snippets/c++-mode/sleep
@@ -3,4 +3,4 @@
 # key: sleep
 # binding: direct-keybinding
 # --
-bcemt_ThreadUtil::sleep(bdet_TimeInterval(1.0));
+bslmt::ThreadUtil::sleep(bsls::TimeInterval(1.0));


### PR DESCRIPTION
BDE has evolved a bit and deprecated some of them. I've chosen the monotonic clock as it seemed more relevant to the time measurements in the backend.