### PR TITLE
Don't use git gutter for remote files

### DIFF
--- a/modules/init-git.el
+++ b/modules/init-git.el
@@ -68,16 +68,26 @@
 
 ;;; Git gutter fringe: display added/removed/changed lines in the left fringe.
 
+;;;###autoload
+(define-globalized-minor-mode exordium-global-git-gutter-mode
+  git-gutter-mode
+  (lambda () (when (let ((file-name (buffer-file-name)))
+                     (if exordium-git-gutter-for-remote-files
+                         file-name ;; enable for all files
+                       (and file-name ;; enable only for local files
+                            (not (file-remote-p file-name)))))
+               (git-gutter--turn-on))))
+
 (when exordium-git-gutter-non-fringe
   (setq exordium-git-gutter nil)
   (require 'git-gutter)
-  (global-git-gutter-mode t)
+  (exordium-global-git-gutter-mode t)
   (git-gutter:linum-setup)
   (diminish 'git-gutter-mode))
 
 (when (and exordium-git-gutter (not exordium-git-gutter-non-fringe))
   (require 'git-gutter-fringe)
-  (global-git-gutter-mode t)
+  (exordium-global-git-gutter-mode t)
   (diminish 'git-gutter-mode))
 
 ;; Keys

--- a/modules/init-prefs.el
+++ b/modules/init-prefs.el
@@ -338,6 +338,12 @@ Disables flyspell if set to nil."
   :group 'exordium
   :type  'boolean)
 
+(defcustom exordium-git-gutter-for-remote-files nil
+  "Whether a git status icon is displayed for the remote files, i.e.
+opened in TRAMP mode."
+  :group 'exordium
+  :type  'boolean)
+
 ;;; See init-cpp.el
 (defcustom exordium-enable-c++11-keywords :simple
   "Enables syntax highlighting for the new keywords introduced in C++11 if set


### PR DESCRIPTION
Added this as an opt-out as the git-gutter was responsible for
~2/3 of the time emacs was 'tramping' for remote files in git
repository.