### PR TITLE
Add ^c g n and ^c g p for git gutter hunks navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,7 +373,9 @@ Git gutter keys:
 Keybinding            | Description
 ----------------------|-----------------------------------------------------------
 <kbd>C-c g down</kbd> | Goto next hunk in buffer (`git-gutter:next-hunk`).
+<kbd>C-c g n</kbd> | Goto next hunk in buffer (`git-gutter:next-hunk`).
 <kbd>C-c g up</kbd>   | Goto previous hunk in buffer (`git-gutter:previous-hunk`).
+<kbd>C-c g p</kbd>   | Goto previous hunk in buffer (`git-gutter:previous-hunk`).
 <kbd>C-c g d</kbd>    | Diff the current hunk (`git-gutter:popup-diff`).
 <kbd>C-c g r</kbd>    | Revert the current hunk after confirmation (`git-gutter:revert-hunk`).
 

--- a/modules/init-git.el
+++ b/modules/init-git.el
@@ -11,7 +11,9 @@
 ;;; C-c g b           Toggle Magit blame mode
 ;;;
 ;;; C-c g down        Goto next hunk in buffer
+;;; C-c g n           Goto next hunk in buffer
 ;;; C-c g up          Goto previous hunk in buffer
+;;; C-c g p           Goto previous hunk in buffer
 ;;; C-c g d           Diff current hunk
 ;;; C-c g r           Revert current hunk (asks for confirmation)
 
@@ -93,7 +95,9 @@
 ;; Keys
 (when (or exordium-git-gutter exordium-git-gutter-non-fringe)
   (define-key exordium-git-map (kbd "<down>") 'git-gutter:next-hunk)
+  (define-key exordium-git-map (kbd "n") 'git-gutter:next-hunk)
   (define-key exordium-git-map (kbd "<up>") 'git-gutter:previous-hunk)
+  (define-key exordium-git-map (kbd "p") 'git-gutter:previous-hunk)
   (define-key exordium-git-map (kbd "d") 'git-gutter:popup-hunk)
   (define-key exordium-git-map (kbd "r") 'git-gutter:revert-hunk))
 


### PR DESCRIPTION
I find these keys to be easier to reach on MacBook keyboard.