### PR TITLE
Use `magit-dired-log` when in `dired-mode`

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ Magit keys:
 Keybinding            | Description
 ----------------------|-----------------------------------------------------------
 <kbd>C-c g s</kbd>    | Open git status (`magit-status`).
-<kbd>C-c g l</kbd>    | Open git log (`magit-log`).
+<kbd>C-c g l</kbd>    | Open git log (`magit-log` or `magit-dired-log` when in `dired-mode`).
 <kbd>C-c g f</kbd>    | Open git file log (`magit-file-log`).
 <kbd>C-c g b</kbd>    | Toggles git blame mode on and off (`magit-blame-mode`).
 <kbd>C-c g g</kbd>    | Git grep (`vc-git-grep`) or (`helm-grep-do-git-grep`).

--- a/modules/init-git.el
+++ b/modules/init-git.el
@@ -20,13 +20,20 @@
 ;;; Magit
 (require 'magit)
 
+(defun exordium-magit-log ()
+  "If in `dired-mode', call `magit-dired-log'. Otherwise call
+`magit-log-current (or `magit-log' if former not present)."
+    (interactive)
+    (if (eq 'dired-mode major-mode)
+        (call-interactively 'magit-dired-log)
+      (if (fboundp 'magit-log-current)
+          (call-interactively 'magit-log-current)
+        (call-interactively 'magit-log))))
+
 ;;; Keys
 (define-prefix-command 'exordium-git-map nil)
 (define-key exordium-git-map (kbd "s") (function magit-status))
-(define-key exordium-git-map (kbd "l")
-  (if (fboundp 'magit-log-current)
-      (function magit-log-current)
-    (function magit-log)))
+(define-key exordium-git-map (kbd "l") 'exordium-magit-log)
 (define-key exordium-git-map (kbd "f")
   (if (fboundp 'magit-log-buffer-file)
       (function magit-log-buffer-file)


### PR DESCRIPTION
In my mind this is more dwim. And nice when digging through repo history.