### PR TITLE
Add magit-clone to the git keymap

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,7 @@ Keybinding            | Description
 <kbd>C-c g l</kbd>    | Open git log (`magit-log` or `magit-dired-log` when in `dired-mode`).
 <kbd>C-c g f</kbd>    | Open git file log (`magit-file-log`).
 <kbd>C-c g b</kbd>    | Toggles git blame mode on and off (`magit-blame-mode`).
+<kbd>C-c g c</kbd>    | Clone a repository (`magit-clone`).
 <kbd>C-c g g</kbd>    | Git grep (`vc-git-grep`) or (`helm-grep-do-git-grep`).
 
 Git gutter keys:

--- a/modules/init-git.el
+++ b/modules/init-git.el
@@ -9,6 +9,7 @@
 ;;; C-c g l           Magit log
 ;;; C-c g f           Magit file log
 ;;; C-c g b           Toggle Magit blame mode
+;;; C-c g c           Magit clone
 ;;;
 ;;; C-c g down        Goto next hunk in buffer
 ;;; C-c g n           Goto next hunk in buffer
@@ -42,6 +43,7 @@
   (if (fboundp 'magit-blame)
       (function magit-blame)
     (function magit-blame-mode)))
+(define-key exordium-git-map (kbd "c") (function magit-clone))
 (global-set-key (kbd "C-c g") 'exordium-git-map)
 
 ;;; Make `magit-status' run alone in the frame, and then restore the old window


### PR DESCRIPTION
I find myself using it more and more in recent days, especially when the
default in my `magit-clone-name-alist` lets me to use only `organisation/repo`
to specify the source of a clone.